### PR TITLE
优化type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,5 +8,5 @@
     "ecmaVersion": 7,
     "sourceType": "module"
   },
-  "parser": "babel-eslint"
+  "parser": "@typescript-eslint/parser"
 }

--- a/lib/pinyin.ts
+++ b/lib/pinyin.ts
@@ -20,17 +20,26 @@ const DEFAULT_OPTIONS: {
   multiple: false,
 };
 
-type PinyinFn = (
+function pinyinFn(
   word: string,
   options?: {
     toneType?: 'symbol' | 'num' | 'none';
     pattern?: 'pinyin' | 'initial' | 'final' | 'num' | 'first';
-    type?: 'string' | 'array';
+    type?: 'string';
     multiple?: boolean;
   }
-) => string | string[];
+): string;
+function pinyinFn(
+  word: string,
+  options?: {
+    toneType?: 'symbol' | 'num' | 'none';
+    pattern?: 'pinyin' | 'initial' | 'final' | 'num' | 'first';
+    type: 'array';
+    multiple?: boolean;
+  }
+): string[];
 
-const pinyinFn: PinyinFn = (word, options = DEFAULT_OPTIONS) => {
+function pinyinFn (word: string, options = DEFAULT_OPTIONS): string | string[] {
   // word传入类型错误时
   if (typeof word !== 'string') {
     return word;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/jest": "^26.0.20",
+    "@typescript-eslint/eslint-plugin": "^4.26.0",
+    "@typescript-eslint/parser": "^4.26.0",
     "babel-eslint": "^10.1.0",
     "chai": "^4.3.4",
     "commitizen": "^4.2.2",

--- a/types/lib/pinyin.d.ts
+++ b/types/lib/pinyin.d.ts
@@ -1,8 +1,13 @@
-declare type PinyinFn = (word: string, options?: {
+declare function pinyinFn(word: string, options?: {
     toneType?: 'symbol' | 'num' | 'none';
     pattern?: 'pinyin' | 'initial' | 'final' | 'num' | 'first';
-    type?: 'string' | 'array';
+    type?: 'string';
     multiple?: boolean;
-}) => string | string[];
-declare const pinyinFn: PinyinFn;
+}): string;
+declare function pinyinFn(word: string, options?: {
+    toneType?: 'symbol' | 'num' | 'none';
+    pattern?: 'pinyin' | 'initial' | 'final' | 'num' | 'first';
+    type: 'array';
+    multiple?: boolean;
+}): string[];
 export { pinyinFn };


### PR DESCRIPTION
使用typescript的函数重载，使之可以通过函数参数确定返回值是string还是string[]

修改.eslintrc:
- babel-eslint不支持typescript的函数重载语法，所以需要更换为@typescript-eslint/parser