### PR TITLE
refactor: 变调选项由 inflection 改为 toneSandhi

### DIFF
--- a/lib/core/html/index.ts
+++ b/lib/core/html/index.ts
@@ -32,11 +32,11 @@ interface HtmlOptions {
     [classname: string]: string[];
   };
   /**
-   * @description 是否对"一"和"不"开启变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
+   * @description 是否开启「一」和 「不」字的变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
    * @value true：开启
    * @value false：不开启
    */
-  inflection?: boolean;
+  toneSandhi?: boolean;
 }
 
 const DefaultHtmlOptions: HtmlOptions = {
@@ -47,7 +47,7 @@ const DefaultHtmlOptions: HtmlOptions = {
   wrapNonChinese: false,
   toneType: 'symbol',
   customClassMap: {},
-  inflection: true,
+  toneSandhi: true,
 };
 
 /**
@@ -64,7 +64,7 @@ export const html = (text: string, options?: HtmlOptions) => {
   const pinyinArray = pinyin(text, {
     type: 'all',
     toneType: completeOptions.toneType,
-    inflection: options?.inflection,
+    toneSandhi: options?.toneSandhi,
   });
   const result = pinyinArray.map((item) => {
     let additionalClass = '';

--- a/lib/core/pinyin/index.ts
+++ b/lib/core/pinyin/index.ts
@@ -9,7 +9,7 @@ import {
   middlewareV,
   middlewareType,
   middlewareDoubleUnicode,
-  middlewareInflection,
+  middlewareToneSandhi,
 } from './middlewares';
 
 interface BasicOptions {
@@ -72,11 +72,11 @@ interface BasicOptions {
    */
   v?: boolean;
   /**
-   * @description 是否对"一"和"不"开启变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
+   * @description 是否开启「一」和 「不」字的变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
    * @value true：开启
    * @value false：不开启
    */
-  inflection?: boolean;
+  toneSandhi?: boolean;
 }
 
 interface AllData {
@@ -150,7 +150,7 @@ const DEFAULT_OPTIONS: CompleteOptions = {
   nonZh: 'spaced',
   v: false,
   separator: ' ',
-  inflection: true,
+  toneSandhi: true,
 };
 
 /**
@@ -216,7 +216,7 @@ function pinyin(
   list = getPinyin(word, list, options.mode || 'normal');
 
   // 一和不变调处理
-  list = middlewareInflection(list, options.inflection as boolean);
+  list = middlewareToneSandhi(list, options.toneSandhi as boolean);
 
   // 双 unicode 编码字符处理
   list = middlewareDoubleUnicode(list);

--- a/lib/core/pinyin/middlewares.ts
+++ b/lib/core/pinyin/middlewares.ts
@@ -224,11 +224,11 @@ export const middlewareDoubleUnicode = (
 };
 
 // 是否开启变调
-export const middlewareInflection = (
+export const middlewareToneSandhi = (
   list: SingleWordResult[],
-  inflection: boolean,
+  toneSandhi: boolean,
 ): SingleWordResult[] => {
-  if (inflection === false) {
+  if (toneSandhi === false) {
     list.forEach(item => {
       if (item.origin === '一') {
         item.result = item.originPinyin = 'yī';

--- a/lib/data/special.ts
+++ b/lib/data/special.ts
@@ -162,9 +162,9 @@ export const PatternNumberDict: Pattern[] = Object.keys(NumberDict).map(
 );
 
 /**
- * @description: 特殊变调处理：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
+ * @description: 连续变调处理：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
  */
-const inflectionMap = {
+const toneSandhiMap = {
   // 说不说，说一说，叠词之间发音为轻声
   不: {
     bú: [4], // "不" 后面跟 4 声时，变调为 2 声
@@ -174,24 +174,24 @@ const inflectionMap = {
     yì: [1, 2, 3],
   },
 };
-const inflectionIgnoreSuffix = ['的', '地', '而', '之', '后', '也', '还'];
-export const inflectionList = Object.keys(inflectionMap);
+const toneSandhiIgnoreSuffix = ['的', '地', '而', '之', '后', '也', '还'];
+export const toneSandhiList = Object.keys(toneSandhiMap);
 
-// 处理 一、不 的变调
-export function processInflection(cur: string, pre: string, next: string) {
-  if (inflectionList.indexOf(cur) === -1) {
+// 处理「一」和 「不」字的变调
+export function processToneSandhi(cur: string, pre: string, next: string) {
+  if (toneSandhiList.indexOf(cur) === -1) {
     return getSingleWordPinyin(cur);
   }
-  // 说不说，说一说，叠词之间发音为轻声
+  // 轻声变调：说不说，说一说，叠词之间发音为轻声
   if (pre === next && getSingleWordPinyin(pre) !== pre) {
     return getPinyinWithoutTone(getSingleWordPinyin(cur));
   }
-  // 一、不的变调处理
-  if (next && !inflectionIgnoreSuffix.includes(next)) {
+  // 「一」和 「不」字变调处理
+  if (next && !toneSandhiIgnoreSuffix.includes(next)) {
     const nextPinyin = getSingleWordPinyin(next);
     if (nextPinyin !== next) {
       const nextTone = getNumOfTone(nextPinyin);
-      const pinyinMap = inflectionMap[cur as keyof typeof inflectionMap];
+      const pinyinMap = toneSandhiMap[cur as keyof typeof toneSandhiMap];
       for (let pinyin in pinyinMap) {
         const tones = pinyinMap[pinyin as keyof typeof pinyinMap] as number[];
         if (tones.indexOf(Number(nextTone)) !== -1) {
@@ -202,8 +202,8 @@ export function processInflection(cur: string, pre: string, next: string) {
   }
 }
 
-// 处理 了
-export function processInflectionLiao(cur: string, pre: string) {
+// 处理「了」字的变调
+export function processToneSandhiLiao(cur: string, pre: string) {
   if (cur === '了' && !isZhChar(pre)) {
     return 'liǎo';
   }
@@ -211,8 +211,8 @@ export function processInflectionLiao(cur: string, pre: string) {
 
 export function processSepecialPinyin(cur: string, pre: string, next: string) {
   return (
-    processInflectionLiao(cur, pre) ||
-    processInflection(cur, pre, next) ||
+    processToneSandhiLiao(cur, pre) ||
+    processToneSandhi(cur, pre, next) ||
     getSingleWordPinyin(cur)
   );
 }

--- a/test/special.test.js
+++ b/test/special.test.js
@@ -66,7 +66,7 @@ describe('special change tone', () => {
   });
 
   it('[special change tone]一会儿', () => {
-    const result = pinyin('一会儿', { inflection: false });
+    const result = pinyin('一会儿', { toneSandhi: false });
     expect(result).to.be.equal('yī huì er');
   });
 });

--- a/types/core/html/index.d.ts
+++ b/types/core/html/index.d.ts
@@ -30,11 +30,11 @@ interface HtmlOptions {
         [classname: string]: string[];
     };
     /**
-     * @description 是否对"一"和"不"开启变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
+     * @description 是否开启「一」和 「不」字的变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
      * @value true：开启
      * @value false：不开启
      */
-    inflection?: boolean;
+    toneSandhi?: boolean;
 }
 /**
  * @description: 获取带拼音汉字的 html 字符串

--- a/types/core/pinyin/index.d.ts
+++ b/types/core/pinyin/index.d.ts
@@ -50,11 +50,11 @@ interface BasicOptions {
      */
     v?: boolean;
     /**
-     * @description 是否对"一"和"不"开启变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
+     * @description 是否开启「一」和 「不」字的变调。默认开启。参考：https://zh.wiktionary.org/wiki/Appendix:%E2%80%9C%E4%B8%80%E2%80%9D%E5%8F%8A%E2%80%9C%E4%B8%8D%E2%80%9D%E7%9A%84%E5%8F%98%E8%B0%83
      * @value true：开启
      * @value false：不开启
      */
-    inflection?: boolean;
+    toneSandhi?: boolean;
 }
 interface AllData {
     origin: string;

--- a/types/core/pinyin/middlewares.d.ts
+++ b/types/core/pinyin/middlewares.d.ts
@@ -19,4 +19,4 @@ export declare const middlewareType: (list: SingleWordResult[], options: Complet
     isZh: boolean;
 }[];
 export declare const middlewareDoubleUnicode: (list: SingleWordResult[]) => SingleWordResult[];
-export declare const middlewareInflection: (list: SingleWordResult[], inflection: boolean) => SingleWordResult[];
+export declare const middlewareToneSandhi: (list: SingleWordResult[], toneSandhi: boolean) => SingleWordResult[];

--- a/types/data/special.d.ts
+++ b/types/data/special.d.ts
@@ -26,7 +26,7 @@ export declare const SpecialFinalMap: {
 };
 export declare const doubleFinalList: string[];
 export declare const PatternNumberDict: Pattern[];
-export declare const inflectionList: string[];
-export declare function processInflection(cur: string, pre: string, next: string): string | undefined;
-export declare function processInflectionLiao(cur: string, pre: string): "liǎo" | undefined;
+export declare const toneSandhiList: string[];
+export declare function processToneSandhi(cur: string, pre: string, next: string): string | undefined;
+export declare function processToneSandhiLiao(cur: string, pre: string): "liǎo" | undefined;
 export declare function processSepecialPinyin(cur: string, pre: string, next: string): string;


### PR DESCRIPTION
## PR 的功能

连续变调是一个专业术语，这个 PR 将该选项由 `inflection` 改为 `toneSandhi`

虽然 `Tone changes` 中的 changes 会更加通俗一些，但是 Wiki 百科说道：

> Tone sandhi is compulsory as long as the environmental conditions that trigger it are met. It is not to be confused with tone changes that are due to derivational or inflectional morphology.
> https://en.wikipedia.org/wiki/Tone_sandhi

## 是否进行了详细的自测？

是

https://github.com/zh-lx/pinyin-pro/issues/167 的一部分。
