### PR TITLE
fix: 「一地」连用时需要变调为二声

### DIFF
--- a/lib/data/special.ts
+++ b/lib/data/special.ts
@@ -174,7 +174,7 @@ const toneSandhiMap = {
     yì: [1, 2, 3],
   },
 };
-const toneSandhiIgnoreSuffix = ['的', '地', '而', '之', '后', '也', '还'];
+const toneSandhiIgnoreSuffix = ['的', '而', '之', '后', '也', '还'];
 export const toneSandhiList = Object.keys(toneSandhiMap);
 
 // 处理「一」和 「不」字的变调

--- a/test/special.test.js
+++ b/test/special.test.js
@@ -28,45 +28,117 @@ describe('number', () => {
   });
 });
 
-
-describe('special change tone', () => {
-  it('[special change tone]一面', () => {
+// 连续变调
+describe('tone sandhi for “一”', () => {
+  it('[special tone sandhi]一面', () => {
     const result = pinyin('一面');
     expect(result).to.be.equal('yí miàn');
   });
 
-  it('[special change tone]一枕黄粱', () => {
+  it('[special tone sandhi]一枕黄粱', () => {
     const result = pinyin('一枕黄粱');
     expect(result).to.be.equal('yì zhěn huáng liáng');
   });
 
-  it('[special change tone]说一说', () => {
+  it('[special tone sandhi]说一说', () => {
     const result = pinyin('说一说');
     expect(result).to.be.equal('shuō yi shuō');
   });
 
-  it('[special change tone]不甘', () => {
-    const result = pinyin('不甘');
-    expect(result).to.be.equal('bù gān');
-  });
-
-  it('[special change tone]不悦', () => {
-    const result = pinyin('不悦');
-    expect(result).to.be.equal('bú yuè');
-  });
-
-  it('[special change tone]说不说', () => {
-    const result = pinyin('说不说');
-    expect(result).to.be.equal('shuō bu shuō');
-  });
-
-  it('[special change tone]一会儿', () => {
+  it('[special tone sandhi]一会儿', () => {
     const result = pinyin('一会儿');
     expect(result).to.be.equal('yí huì er');
   });
 
-  it('[special change tone]一会儿', () => {
+  it('[special tone sandhi for toneSandhi false]一会儿', () => {
     const result = pinyin('一会儿', { toneSandhi: false });
     expect(result).to.be.equal('yī huì er');
+  });
+
+  it('[special tone sandhi]一地鸡毛', () => {
+    const result = pinyin('一地鸡毛');
+    expect(result).to.be.equal('yí dì jī máo');
+  });
+
+  it('[special tone sandhi]洒了一地', () => {
+    const result = pinyin('洒了一地');
+    expect(result).to.be.equal('sǎ le yí dì');
+  });
+
+  it('[special tone sandhi]一地', () => {
+    const result = pinyin('一地');
+    expect(result).to.be.equal('yí dì');
+  });
+
+  // TODO: 连读数字（只有开头的「一」变调）
+  it.skip('[special tone sandhi]一千一百一十一', () => {
+    const result = pinyin('一千一百一十一');
+    expect(result).to.be.equal('yì qiān yī bǎi yī shí yī');
+  });
+
+  // TODO: 连续数字不变调
+  it.skip('[special tone sandhi]一二三四五', () => {
+    const result = pinyin('一二三四五');
+    expect(result).to.be.equal('yī èr sān sì wǔ');
+  });
+
+  // TODO: 文言文中的时间不变调
+  it.skip('[special tone sandhi]十有一年而弃', () => {
+    const result = pinyin('十有一年而弃');
+    expect(result).to.be.equal('shí yòu yī nián ér qì');
+  });
+
+  // TODO: 作为时间时不变调
+  it.skip('[special tone sandhi]九一年', () => {
+    const result = pinyin('九一年');
+    expect(result).to.be.equal('jiǔ yī nián');
+  });
+
+  // TODO: 作为序数时不变调
+  it.skip('[special tone sandhi]一路公交', () => {
+    const result = pinyin('一路公交');
+    expect(result).to.be.equal('yī lù gōng jiāo');
+  });
+
+  // 但同样的词「一路」作为非序数时却要变调
+  it('[special tone sandhi]一路顺风', () => {
+    const result = pinyin('一路顺风');
+    expect(result).to.be.equal('yí lù shùn fēng');
+  });
+
+  // TODO: 成语中的序数也不变调
+  it.skip('[special tone sandhi]有一说一', () => {
+    const result = pinyin('有一说一');
+    expect(result).to.be.equal('yǒu yī shuō yī');
+  });
+});
+
+describe('tone sandhi for “不”', () => {
+  // 不变调
+  it('[special tone sandhi]不甘', () => {
+    const result = pinyin('不甘');
+    expect(result).to.be.equal('bù gān');
+  });
+
+  it('[special tone sandhi]他说不！', () => {
+    const result = pinyin('他说不！');
+    expect(result).to.be.equal('tā shuō bù ！');
+  });
+
+  it('[special tone sandhi]要不你走', () => {
+    const result = pinyin('要不你走');
+    expect(result).to.be.equal('yào bù nǐ zǒu');
+  });
+
+  // 变调为二声
+  it('[special tone sandhi]不悦', () => {
+    const result = pinyin('不悦');
+    expect(result).to.be.equal('bú yuè');
+  });
+
+  // 变调为轻声
+  it('[special tone sandhi]说不说', () => {
+    const result = pinyin('说不说');
+    expect(result).to.be.equal('shuō bu shuō');
   });
 });


### PR DESCRIPTION
## PR 的功能

toneSandhiIgnoreSuffix 数组中去掉「地」，在这个 PR 之前，「一地」连用时不变调。

如：`一地鸡毛、洒了一地` 都需要变调为二声。

此外增加了更多「一」变调相关的测试

----

https://github.com/zh-lx/pinyin-pro/issues/167 的一部分
