### PR TITLE
feat: isZh 字段现在可以准确判断是否为中文

### DIFF
--- a/lib/common/type.ts
+++ b/lib/common/type.ts
@@ -4,6 +4,7 @@ export interface SingleWordResult {
   originPinyin: string;
   result: string;
   isZh: boolean;
+  hasPinyin: boolean;
   delete?: boolean;
 }
 

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -22,10 +22,15 @@ export function getSplittedWord(string: string) {
   return arr;
 }
 
+// 根据 Unicode 的定义判断是否为中文（表意文字）
 export function isZhChar(char: string) {
   if (typeof char !== 'string') {
     return false;
   }
-  let code = char.charCodeAt(0);
-  return code >= 19968 && code <= 40869;
+
+  // 通过 Unicode property escapes，方便扩展支持其他文字
+  // 文章：https://zhuanlan.zhihu.com/p/33335629
+  // Spec: https://github.com/tc39/proposal-regexp-unicode-property-escapes
+  // 可以测试生僻字 鿏
+  return /^[\p{Unified_Ideograph}]+$/ui.test(char)
 }

--- a/lib/core/pinyin/handle.ts
+++ b/lib/core/pinyin/handle.ts
@@ -16,6 +16,8 @@ import {
   DoubleUnicodeSuffixReg,
 } from '@/common/constant';
 
+import { isZhChar } from '@/common/utils';
+
 /**
  * @description: 获取单个字符的拼音
  * @param {string} word
@@ -74,6 +76,7 @@ export const getPinyin = (
             origin: match.zh[j],
             result: '',
             isZh: true,
+            hasPinyin: true,
             originPinyin: '',
           };
         } else {
@@ -81,6 +84,7 @@ export const getPinyin = (
             origin: match.zh[j],
             result: pinyins[pinyinIndex],
             isZh: true,
+            hasPinyin: true,
             originPinyin: pinyins[pinyinIndex],
           };
           pinyinIndex++;
@@ -95,7 +99,8 @@ export const getPinyin = (
       list[i] = {
         origin: char,
         result: pinyin,
-        isZh: pinyin !== char,
+        isZh: isZhChar(char),
+        hasPinyin: pinyin !== char,
         originPinyin: pinyin,
       };
       i++;
@@ -144,6 +149,7 @@ const getMultiplePinyin: GetMultiplePinyin = (word, mode = 'normal') => {
       origin: word,
       result: value,
       isZh: true,
+      hasPinyin: true,
       originPinyin: value,
     }));
   } else {
@@ -152,6 +158,7 @@ const getMultiplePinyin: GetMultiplePinyin = (word, mode = 'normal') => {
         origin: word,
         result: word,
         isZh: false,
+        hasPinyin: false,
         originPinyin: word,
       },
     ];

--- a/lib/core/pinyin/middlewares.ts
+++ b/lib/core/pinyin/middlewares.ts
@@ -179,7 +179,7 @@ export const middlewareType = (
   }
   if (options.type === 'all') {
     return list.map((item) => {
-      const pinyin = item.isZh ? item.result : '';
+      const pinyin = item.hasPinyin ? item.result : '';
       const { initial, final } = getInitialAndFinal(pinyin);
       const { head, body, tail } = getFinalParts(pinyin);
       return {
@@ -187,7 +187,7 @@ export const middlewareType = (
         pinyin,
         initial,
         final,
-        first: item.isZh ? getFirstLetter(item.result) : '',
+        first: item.hasPinyin ? getFirstLetter(item.result) : '',
         finalHead: head,
         finalBody: body,
         finalTail: tail,

--- a/lib/core/polyphonic/index.ts
+++ b/lib/core/polyphonic/index.ts
@@ -212,6 +212,7 @@ const getPolyphonicList = (text: string): SingleWordResult[] => {
       origin: word,
       result: pinyin,
       isZh: !!pinyin,
+      hasPinyin: !!pinyin,
       originPinyin: pinyin,
     };
   });
@@ -227,6 +228,7 @@ const getSplittedPolyphonicList = (
           origin: item.origin,
           result: pinyin,
           isZh: true,
+          hasPinyin: true,
           originPinyin: pinyin,
         }))
       : [item];

--- a/types/common/type.d.ts
+++ b/types/common/type.d.ts
@@ -3,6 +3,7 @@ export interface SingleWordResult {
     originPinyin: string;
     result: string;
     isZh: boolean;
+    hasPinyin: boolean;
     delete?: boolean;
 }
 export type ToneType = 'symbol' | 'num' | 'none';


### PR DESCRIPTION
内部新增 `hasPinyin` 来判断是否有拼音数据，isZh 现在纯粹表达字符是否为中文，
无论字典中是否有拼音。

https://github.com/zh-lx/pinyin-pro/issues/169 的一部分。

