### PR TITLE
fix: 字典添加「哈什蚂」的正确读音

### DIFF
--- a/lib/data/dict2.ts
+++ b/lib/data/dict2.ts
@@ -2179,6 +2179,7 @@ const DICT2: { [prop: string]: string } = {
   行行: 'háng háng',
   哪行: 'nǎ háng',
   不行: 'bù xíng',
+  仡佬: 'gē lǎo',
 };
 export default DICT2;
 export const Pattern2: Pattern[] = Object.keys(DICT2).map((key) => ({

--- a/lib/data/dict3.ts
+++ b/lib/data/dict3.ts
@@ -25,7 +25,6 @@ const DICT3: { [prop: string]: string } = {
   发脾气: 'fā pí qi',
   士大夫: 'shì dà fū',
   三部曲: 'sān bù qǔ',
-  仡佬族: 'gē lǎo zú',
   交响曲: 'jiāo xiǎng qǔ',
   鸭绿江: 'yā lù jiāng',
   协奏曲: 'xié zòu qǔ',
@@ -186,6 +185,8 @@ const DICT3: { [prop: string]: string } = {
   飞将军: 'fēi jiāng jūn',
   挑大梁: 'tiǎo dà liáng',
   哈巴狗: 'hǎ ba gǒu',
+  哈什蚂: 'hà shí mǎ',
+  哈士蟆: 'hà shi má', // 新华字典第 12 版第 175 页
   过家家: 'guò jiā jiā',
   催泪弹: 'cuī lèi dàn',
   雨夹雪: 'yǔ jiā xuě',

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -33,10 +33,10 @@ describe('customConfig', () => {
 
   it('[custom]custom3', () => {
     customPinyin({
-      哈什玛: 'hà shén mǎ',
+      呵呀: 'ā ya', // 武松见了，叫声：“呵呀！” ——部编版五年级(下) 景阳冈
     });
-    const result = pinyin('哈什玛');
-    expect(result).to.be.equal('hà shén mǎ');
+    const result = pinyin('呵呀');
+    expect(result).to.be.equal('ā ya');
     clearAllCustomDicts();
   });
 


### PR DESCRIPTION
「清蒸哈什蚂」常见于经典相声《报菜名》