### PR TITLE
fix: pinyin() 方法中只有一个非中文时无法丢失该字符

### DIFF
--- a/lib/core/pinyin/handle.ts
+++ b/lib/core/pinyin/handle.ts
@@ -176,8 +176,7 @@ type GetMultiplePinyin = (
 ) => SingleWordResult[];
 const getMultiplePinyin: GetMultiplePinyin = (word, mode = 'normal') => {
   let pinyin = getAllPinyin(word, mode);
-  
-  if (pinyin) {
+  if (pinyin.length > 0) {
     return pinyin.map((value) => ({
       origin: word,
       result: value,

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -221,4 +221,29 @@ describe('all', () => {
       },
     ]);
   });
+
+  // 非汉字，越南喃字
+  it('[all]非中文：字母', () => {
+    const result = pinyin('a', {
+      type: 'all',
+      multiple: true,
+    });
+
+    expect(result.length).to.be.equal(1)
+    expect(result[0]?.pinyin).to.be.equal('')
+    expect(result[0]?.origin).to.be.equal('a')
+    expect(result[0]?.inZhRange).to.be.equal(false)
+  });
+
+  it('[all]非中文和中文混合', () => {
+    const result = pinyin('a好', {
+      type: 'all',
+      multiple: true,
+    });
+
+    expect(result.length).to.be.equal(2)
+    expect(result[1]?.pinyin).to.be.equal('hǎo')
+    expect(result[1]?.origin).to.be.equal('好')
+    expect(result[1]?.polyphonic.toString()).to.be.equal('hǎo,hào')
+  });
 });

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -53,15 +53,38 @@ describe('html', () => {
   });
 
   it('[html]正常拼音', () => {
-    const result = html('汉语拼音', { 
+    const result = html('汉语拼音', {
       customClassMap: {
         'hightlight': ['汉', '拼'],
         'bold': ['音'],
         'useless': ['你'],
-      } 
+      }
     });
     expect(result).to.be.equal(
       '<span class="py-result-item hightlight"><ruby><span class="py-chinese-item">汉</span><rp>(</rp><rt class="py-pinyin-item">hàn</rt><rp>)</rp></ruby></span><span class="py-result-item"><ruby><span class="py-chinese-item">语</span><rp>(</rp><rt class="py-pinyin-item">yǔ</rt><rp>)</rp></ruby></span><span class="py-result-item hightlight"><ruby><span class="py-chinese-item">拼</span><rp>(</rp><rt class="py-pinyin-item">pīn</rt><rp>)</rp></ruby></span><span class="py-result-item bold"><ruby><span class="py-chinese-item">音</span><rp>(</rp><rt class="py-pinyin-item">yīn</rt><rp>)</rp></ruby></span>'
     );
   });
+
+  it('[html]非汉字：字母a', () => {
+    const result = html('a');
+    expect(result).to.be.equal('a');
+  });
+
+  it('[html]非中国汉字：𦒹', () => {
+    const result = html('𦒹');
+    expect(result).to.be.equal('𦒹');
+  });
+
+  it('[html]非中国汉字 + wrapNonChinese: true', () => {
+    const result = html('𦒹', {
+      wrapNonChinese: true,
+    });
+    expect(result).to.be.equal('<span class="py-non-chinese-item">𦒹</span>');
+  });
+
+  it('[html]非汉字和汉字混合', () => {
+    const result = html('汉字abc');
+    expect(result).to.be.equal('<span class="py-result-item"><ruby><span class="py-chinese-item">汉</span><rp>(</rp><rt class="py-pinyin-item">hàn</rt><rp>)</rp></ruby></span><span class="py-result-item"><ruby><span class="py-chinese-item">字</span><rp>(</rp><rt class="py-pinyin-item">zì</rt><rp>)</rp></ruby></span>abc');
+  });
+
 });

--- a/test/multiple.test.js
+++ b/test/multiple.test.js
@@ -27,9 +27,39 @@ describe('multiple', () => {
     expect(result).to.deep.equal(['hǎo', 'hào']);
   });
 
-  it('[multiple]非字符串', () => {
+  it('[multiple]非汉字：字母', () => {
     const result = pinyin('a', { multiple: true, type: 'array' });
-    expect(result).to.deep.equal([]);
+    expect(result).to.deep.equal(['a']);
+  });
+
+  it('[multiple]非字符串：multiple: false', () => {
+    const result = pinyin('a', { multiple: false, type: 'array' });
+    expect(result).to.deep.equal(['a']);
+  });
+
+  it('[multiple]汉字和非汉字混合：multiple: false', () => {
+    const result = pinyin('Bar好', { multiple: false, type: 'array' });
+    expect(result).to.deep.equal(['B', 'a', 'r', 'hǎo']);
+  });
+
+  it('[multiple]非汉字：多个字母', () => {
+    const result = pinyin('Bar', { multiple: true, type: 'array' });
+    expect(result).to.deep.equal(['B', 'a', 'r']);
+  });
+
+  it('[multiple]非中国汉字：越南喃字', () => {
+    const result = pinyin('𠄼', { multiple: true, type: 'array' });
+    expect(result).to.deep.equal(['𠄼']);
+  });
+
+  it('[multiple]非中国汉字：多个越南喃字', () => {
+    const result = pinyin('𠄼𦒹', { multiple: true, type: 'array' });
+    expect(result).to.deep.equal(['𠄼', '𦒹']);
+  });
+
+  it('[multiple]非中国汉字和汉字混合（多音字仅单字生效）', () => {
+    const result = pinyin('好𠄼𦒹。', { multiple: true, type: 'array' });
+    expect(result).to.deep.equal(['hǎo', '𠄼', '𦒹', '。']);
   });
 
   it('[multiple]multiple+surname同时使用', () => {


### PR DESCRIPTION
这个 PR 修复了 `html()` 等方法中只有一个非中文字符时丢失该字符的问题。

此前 `pinyin()` 存在一些行为不一致：

1. multiple 选项不同，行为不一致 

```js
pinyin('a', { type: 'array', multiple: true }) // → []
pinyin('a', { type: 'array', multiple: false })  // → ['a']
```

2. 单字和多字时行为不一致
```js
pinyin('a', { type: 'array', multiple: true }) // → []
pinyin('ab', { type: 'array', multiple: true })  // → ['a', 'b']
```

**Break Change**

这个 PR 无论是否开启 multiple 选项、无论是单字还是多字，统一返回 `['a']`，并且与 `type: 'all'` 的行为保持一致。