### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "types": "./types/index.d.ts",
         "default": "./dist/index.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "default": "./dist/index.js"
       }
     },
+    "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },
   "devDependencies": {


### PR DESCRIPTION
fix: Package pinyin-pro has been ignored because it contains invalid configuration

遇到的问题: RN工程, 引入后在构建时报错

![image](https://github.com/zh-lx/pinyin-pro/assets/13198448/9ccc9baa-53e0-49ce-82e5-f7168cb2057b)

