### PR TITLE
fix: 修复无法 tree-shake 的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
## PR 描述

即使不导入任何东西，也会打进来 300KB 左右（未开启 minify）的内容，例如：

```typescript
import 'pinyin-pro'
```

经过 vite 打包后，会引进来大概 300 KB 左右的内容。增加 `"sideEffects": false` 后解决

