### PR TITLE
fix: correct custom multiple dict typo

### DIFF
--- a/lib/core/custom/index.ts
+++ b/lib/core/custom/index.ts
@@ -80,7 +80,7 @@ function addCustomConfigToDict(
   }
 }
 
-export const getCustomMultpileDict = () => {
+export const getCustomMultipleDict = () => {
   return customMultipleDict;
 };
 

--- a/lib/core/pinyin/handle.ts
+++ b/lib/core/pinyin/handle.ts
@@ -10,7 +10,7 @@ import {
 } from "@/data/special";
 import Surnames from "@/data/surname";
 import DICT1 from "@/data/dict1";
-import { getCustomMultpileDict } from "@/core/custom";
+import { getCustomMultipleDict } from "@/core/custom";
 import { SingleWordResult } from "../../common/type";
 import type { SurnameMode, InitialPattern } from "../../common/type";
 import {
@@ -138,10 +138,10 @@ const getPinyinWithoutTone: GetPinyinWithoutTone = (pinyin) => {
  */
 type GetAllPinyin = (char: string, surname?: SurnameMode) => string[];
 export const getAllPinyin: GetAllPinyin = (char, surname = "off") => {
-  const customMultpileDict = getCustomMultpileDict();
+  const customMultipleDict = getCustomMultipleDict();
   let pinyin = DICT1.get(char) ? DICT1.get(char).split(" ") : [];
-  if (customMultpileDict.get(char)) {
-    pinyin = customMultpileDict.get(char).split(" ");
+  if (customMultipleDict.get(char)) {
+    pinyin = customMultipleDict.get(char).split(" ");
   } else if (surname !== "off") {
     const surnamePinyin = Surnames[char];
     if (surnamePinyin) {

--- a/types/core/custom/index.d.ts
+++ b/types/core/custom/index.d.ts
@@ -19,7 +19,7 @@ interface CustomPinyinOptions {
 export declare function customPinyin(config?: {
     [word: string]: string;
 }, options?: CustomPinyinOptions): void;
-export declare const getCustomMultpileDict: () => FastDictFactory;
+export declare const getCustomMultipleDict: () => FastDictFactory;
 export declare const getCustomPolyphonicDict: () => FastDictFactory;
 export declare function clearCustomDict(dict: CustomDictType | CustomDictType[]): void;
 export {};


### PR DESCRIPTION
## Summary

Correct the typo `getCustomMultpileDict` to `getCustomMultipleDict` and update all internal references.

## Scope

- rename the helper in `lib/core/custom/index.ts`
- update imports and local variable names in `lib/core/pinyin/handle.ts`
- update the declaration in `types/core/custom/index.d.ts`

## Notes

- no behavior change intended
- local `npm test` passed
- local `npm run build` passed