### PR TITLE
perf(custom): reduce redundant dict lookups and string splits in addCustomConfigToDict

### DIFF
--- a/lib/core/custom/index.ts
+++ b/lib/core/custom/index.ts
@@ -64,16 +64,22 @@ function addCustomConfigToDict(
 ) {
   for (let word in config) {
     const pinyins = config[word];
+    const pinyinList = pinyins.split(' ');
     splitString(word).forEach((char, index) => {
-      const pinyin = pinyins.split(' ')[index] || '';
-      if (handleType === 'replace' || (handleType === 'add' && !dict.get(char) && !DICT1.get(char))) {
+      const pinyin = pinyinList[index] || '';
+      const current = dict.get(char);
+      const base = current || DICT1.get(char);
+      if (handleType === 'replace' || (handleType === 'add' && !base)) {
         // 直接覆盖原词典
         dict.set(char, pinyin);
       } else {
         // 补充至原词典
-        dict.set(char, dict.get(char) || DICT1.get(char));
-        if (!dict.get(char).split(' ').includes(pinyin)) {
-          dict.set(char, `${dict.get(char)} ${pinyin}`.trim());
+        const merged = base as string;
+        if (!current) {
+          dict.set(char, merged);
+        }
+        if (!merged.split(' ').includes(pinyin)) {
+          dict.set(char, `${merged} ${pinyin}`.trim());
         }
       }
     });


### PR DESCRIPTION
Closes #311

## Summary
Hoist repeated `pinyins.split(' ')` out of the `forEach` loop and cache `dict.get(char)` / `DICT1.get(char)` into local variables to avoid redundant lookups in `addCustomConfigToDict`.

## Changes
- `pinyins.split(' ')` moved outside `splitString(word).forEach` — previously re-split per character; now once per word.
- `dict.get(char)` cached as `current`, `DICT1.get(char)` evaluated once as `base` — old code called `dict.get(char)` up to 4 times in the else branch.

No behavioral changes, logic is equivalent.