### PR TITLE
perf(polyphonic): skip unnecessary split+map for single-pronunciation chars in getSplittedPolyphonicList

### DIFF
--- a/lib/core/polyphonic/index.ts
+++ b/lib/core/polyphonic/index.ts
@@ -182,14 +182,25 @@ const getSplittedPolyphonicList = (
   list: SingleWordResult[]
 ): SingleWordResult[][] => {
   return list.map((item) => {
-    return item.isZh
-      ? item.result.split(" ").map((pinyin) => ({
+    if (!item.isZh) {
+      return [item];
+    }
+    if (!item.result.includes(" ")) {
+      return [
+        {
           origin: item.origin,
-          result: pinyin,
+          result: item.result,
           isZh: true,
-          originPinyin: pinyin,
-        }))
-      : [item];
+          originPinyin: item.result,
+        },
+      ];
+    }
+    return item.result.split(" ").map((pinyin) => ({
+      origin: item.origin,
+      result: pinyin,
+      isZh: true,
+      originPinyin: pinyin,
+    }));
   });
 };
 


### PR DESCRIPTION
Closes #313
  
## Summary
Most Chinese characters have a single pronunciation (e.g., `"zhong"`). The old code always called `split(" ")` + `.map()` in `getSplittedPolyphonicList` even when the result contained no spaces, creating unnecessary intermediate arrays.

## Change
Add an early return when `item.result.indexOf(" ") === -1`, skipping both `split()` and `map()` for the common single-pronunciation case.

No behavioral changes.