### PR TITLE
ci: fix bundle-size PR comment failing on fork PRs

### DIFF
--- a/.github/workflows/compare-comment.yaml
+++ b/.github/workflows/compare-comment.yaml
@@ -1,0 +1,79 @@
+name: Comment Bundle Size Comparison
+
+# 在 Bundle Size Comparison 跑完后触发。workflow_run 运行在 base 仓库
+# (zh-lx/pinyin-pro)的上下文中,即使源 PR 来自 fork,GITHUB_TOKEN 仍具备
+# 写权限,因此可以安全地评论 PR——且本 workflow 不会 checkout / 执行任何 PR 代码。
+on:
+  workflow_run:
+    workflows: ['Bundle Size Comparison']
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read # 下载另一个 run 的 artifact 需要
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # 仅在源 run 是 pull_request 触发且成功时评论
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download comparison artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: compare-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment PR with comparison results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const compareOutput = fs.readFileSync('compare-output.txt', 'utf8');
+            const prNumber = parseInt(
+              fs.readFileSync('pr-number.txt', 'utf8').trim(),
+              10
+            );
+
+            // 查找是否已有对比评论
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('📦 CDN vs Local 完整对比')
+            );
+
+            const timestamp = new Date().toUTCString();
+            const body = '## 📦 CDN vs Local 完整对比\n\n```\n' +
+              compareOutput +
+              '\n```\n\n_Updated at ' + timestamp + '_\n\n---\n💡 **提示**: 此评论会在每次推送新提交时自动更新';
+
+            if (botComment) {
+              // 更新现有评论
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+              console.log('✅ 已更新对比评论');
+            } else {
+              // 创建新评论
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+              console.log('✅ 已创建对比评论');
+            }

--- a/.github/workflows/compare.yaml
+++ b/.github/workflows/compare.yaml
@@ -7,12 +7,14 @@ on:
   push:
     branches: [main]
 
+# 只读权限即可：本 workflow 会执行 PR(可能来自 fork)的代码,
+# 评论 PR 的写操作放在 compare-comment.yaml 里完成。
+permissions:
+  contents: read
+
 jobs:
   compare-size:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
 
     steps:
       - name: Checkout code
@@ -30,59 +32,22 @@ jobs:
         run: yarn build
 
       - name: Run comparison (size, accuracy & speed)
-        id: compare
         run: |
-          echo "COMPARE_OUTPUT<<EOF" >> $GITHUB_OUTPUT
-          npm run compare 2>&1 | tee -a $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        continue-on-error: false
+          set -o pipefail
+          npm run compare 2>&1 | tee compare-output.txt
 
-      - name: Comment PR with comparison results
+      - name: Save PR number
         if: github.event_name == 'pull_request'
-        env:
-          COMPARE_OUTPUT: ${{ steps.compare.outputs.COMPARE_OUTPUT }}
-        uses: actions/github-script@v7
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      # 上传对比结果,供 compare-comment.yaml 在有写权限的上下文中下载并评论。
+      # fork PR 的 GITHUB_TOKEN 在此被强制为只读,无法直接评论,故拆分。
+      - name: Upload comparison artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const compareOutput = process.env.COMPARE_OUTPUT;
-
-            // 查找是否已有对比评论
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('📦 CDN vs Local 完整对比')
-            );
-
-            const timestamp = new Date().toUTCString();
-            const body = '## 📦 CDN vs Local 完整对比\n\n```\n' +
-              compareOutput +
-              '\n```\n\n_Updated at ' + timestamp + '_\n\n---\n💡 **提示**: 此评论会在每次推送新提交时自动更新';
-
-            if (botComment) {
-              // 更新现有评论
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-              console.log('✅ 已更新对比评论');
-            } else {
-              // 创建新评论
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-              console.log('✅ 已创建对比评论');
-            }
-
-      - name: Display comparison in logs
-        if: github.event_name == 'push'
-        run: npm run compare
+          name: compare-output
+          path: |
+            compare-output.txt
+            pr-number.txt
+          retention-days: 1


### PR DESCRIPTION
## 背景

`compare-size` job 在来自 **fork** 的 PR 上失败(如 #316),报错:

```
Unhandled error: HttpError: Resource not accessible by integration
```

失败的是 "Comment PR with comparison results" 这一步。根因:对来自 fork 的 `pull_request` 事件,GitHub 出于安全会把 `GITHUB_TOKEN` **强制降为只读**,无论 workflow 里声明了什么 `permissions:`。因此 `issues.createComment` 被拒。构建/对比步骤本身都是成功的,只有需要写权限的评论步骤挂掉。

## 方案

拆分 workflow,让"执行不可信代码"和"写 PR 评论"不再共用一个高权限 token —— 即业界推荐的 `workflow_run` 模式:

- **`compare.yaml`(`pull_request` 触发)**:只负责 build + 跑 compare,把输出和 PR 号作为 artifact 上传。token 保持只读,执行 fork 代码是安全的。
- **`compare-comment.yaml`(新增,`workflow_run` 触发)**:运行在 base 仓库上下文,拥有 `pull-requests: write`,下载 artifact 后发/更新评论。**它不 checkout、不执行任何 PR 代码**,从而规避了直接改用 `pull_request_target` 会带来的 pwn-request 安全风险。

评论逻辑(查找/更新/新建 bot 评论)与原来保持一致,仅把 PR 号改为从 artifact 读取(`workflow_run` 上下文没有 `context.issue.number`)。

## 注意

- `workflow_run` **只会从默认分支(main)的版本触发**,因此本修复**合并到 main 后才生效**。当前失败的 #316 需要在合并后由贡献者 rebase / 推新提交触发一次新的对比 run,评论 workflow 才会接力执行;旧 run 不会回溯。
- 日志里的 `Node.js 20 actions are deprecated` 只是警告、与本次失败无关,本 PR 未改动 action 版本。

## 验证

- 两个 workflow 文件均通过 `js-yaml` 解析校验。
- 合并到 main 后,可在任意 fork PR 上观察:`Bundle Size Comparison` 成功 → `Comment Bundle Size Comparison` 接力并成功评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)