### PR TITLE
fix: use common pronouce of '行长' from cháng to zhǎng

### DIFF
--- a/lib/data/dict2.ts
+++ b/lib/data/dict2.ts
@@ -69,7 +69,7 @@ const DICT2: { [prop: string]: string } = {
   行首: 'háng shǒu',
   行尾: 'háng wěi',
   行末: 'háng mò',
-  行长: 'háng cháng',
+  行长: 'háng zhǎng',
   行距: 'háng jù',
   换行: 'huàn háng',
   行会: 'háng huì',

--- a/test/get-pinyin.test.js
+++ b/test/get-pinyin.test.js
@@ -16,4 +16,9 @@ describe('getPinyin', () => {
     const result = pinyin('阿比让');
     expect(result).to.be.equal('ā bǐ ràng');
   });
+
+  it('[get-pinyin]行长', () => {
+    const result = pinyin('行长');
+    expect(result).to.be.equal('háng zhǎng');
+  });
 });


### PR DESCRIPTION
行长的读音　`háng zhǎng` 比 `háng cháng` 更通用一些