### PR TITLE
ci: add publish and docs deploy workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,52 @@
+name: Deploy docs
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      DEPLOY_HOST:
+        required: true
+      DEPLOY_PATH:
+        required: true
+      DEPLOY_PORT:
+        required: false
+      SERVER_PASSWORD:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+      SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages and docs
+        run: pnpm build:all
+
+      - name: Install deploy dependencies
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Deploy docs
+        run: pnpm deploy:docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: npm dist-tag
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - beta
+      dry_run:
+        description: Run publish in dry-run mode
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish package
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            pnpm --filter pinyin-pro publish --dry-run --no-git-checks --access public --tag "${{ inputs.dist_tag }}"
+          else
+            pnpm --filter pinyin-pro publish --no-git-checks --access public --tag "${{ inputs.dist_tag }}"
+          fi
+
+  deploy-docs:
+    needs: publish
+    if: ${{ !inputs.dry_run }}
+    uses: ./.github/workflows/deploy-docs.yml
+    secrets: inherit

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEPLOY_HOST:?DEPLOY_HOST is required}"
+: "${DEPLOY_PATH:?DEPLOY_PATH is required}"
+
+deploy_port="${DEPLOY_PORT:-22}"
+ssh_options=(-p "${deploy_port}" -o StrictHostKeyChecking=accept-new)
+scp_options=(-P "${deploy_port}" -o StrictHostKeyChecking=accept-new)
+ssh_cmd=(ssh "${ssh_options[@]}")
+scp_cmd=(scp "${scp_options[@]}")
+
+if [[ -n "${SERVER_PASSWORD:-}" ]]; then
+  if ! command -v sshpass >/dev/null 2>&1; then
+    echo "sshpass is required when SERVER_PASSWORD is set." >&2
+    exit 1
+  fi
+
+  export SSHPASS="${SERVER_PASSWORD}"
+  ssh_cmd=(sshpass -e "${ssh_cmd[@]}")
+  scp_cmd=(sshpass -e "${scp_cmd[@]}")
+fi
+
+archive_path="./packages/docs/dist.zip"
+if [[ ! -f "${archive_path}" ]]; then
+  echo "${archive_path} does not exist. Run pnpm build:docs first." >&2
+  exit 1
+fi
+
+remote_path="$(printf '%q' "${DEPLOY_PATH}")"
+
+"${scp_cmd[@]}" "${archive_path}" "${DEPLOY_HOST}:${DEPLOY_PATH}/dist.zip"
+"${ssh_cmd[@]}" "${DEPLOY_HOST}" << EOF
+  set -e
+  cd ${remote_path}
+  rm -rf zh en
+  unzip -q dist.zip
+  rm -f dist.zip
+EOF

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:packages": "pnpm --filter @pinyin-pro/data build && pnpm --filter pinyin-pro build",
     "build:docs": "pnpm --filter @pinyin-pro/docs build",
     "build:all": "pnpm build:packages && pnpm build:docs",
+    "deploy:docs": "bash ./deploy.sh",
     "test": "pnpm --filter pinyin-pro test",
     "lint": "pnpm --filter pinyin-pro lint",
     "compare": "pnpm --filter pinyin-pro compare",


### PR DESCRIPTION
## Summary

- add a manually triggered npm publish workflow with test gating
- add a reusable and manually triggered docs deployment workflow
- deploy the docs automatically after a successful non-dry-run publish
- add the SSH deployment script for the packaged Chinese and English docs

## Validation

- `pnpm test`
- `pnpm build:all`
- workflow formatting and shell syntax checks