### PR TITLE
fix: reset nonZh scope regexp state

### DIFF
--- a/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
@@ -28,6 +28,8 @@ export const validateType = (word: unknown) => {
 
 export function isNonZhScope(char: string, scope?: RegExp) {
   if (scope instanceof RegExp) {
+    // Global and sticky regexes retain lastIndex between calls.
+    scope.lastIndex = 0;
     return scope.test(char);
   }
   return true;

--- a/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
@@ -29,7 +29,9 @@ export const validateType = (word: unknown) => {
 export function isNonZhScope(char: string, scope?: RegExp) {
   if (scope instanceof RegExp) {
     // Global and sticky regexes retain lastIndex between calls.
-    scope.lastIndex = 0;
+    if (scope.global || scope.sticky) {
+      scope.lastIndex = 0;
+    }
     return scope.test(char);
   }
   return true;

--- a/packages/pinyin-pro/test/nonZh.test.js
+++ b/packages/pinyin-pro/test/nonZh.test.js
@@ -36,4 +36,9 @@ describe('nonZh', () => {
     const result4 = pinyin('我very喜欢你，真的', { nonZh: 'consecutive', nonZhScope: /[a-zA-Z]/ });
     expect(result4).to.be.equal('wǒ very xǐ huan nǐ ， zhēn de');
   });
+
+  it('[nonZh]scope global regexp', () => {
+    const result = pinyin('ab', { nonZh: 'removed', nonZhScope: /[a-z]/g });
+    expect(result).to.be.equal('');
+  });
 });

--- a/packages/pinyin-pro/test/nonZh.test.js
+++ b/packages/pinyin-pro/test/nonZh.test.js
@@ -41,4 +41,9 @@ describe('nonZh', () => {
     const result = pinyin('ab', { nonZh: 'removed', nonZhScope: /[a-z]/g });
     expect(result).to.be.equal('');
   });
+
+  it('[nonZh]scope frozen regexp', () => {
+    const result = pinyin('a', { nonZh: 'removed', nonZhScope: Object.freeze(/[a-z]/) });
+    expect(result).to.be.equal('');
+  });
 });


### PR DESCRIPTION
## Summary
- reset global/sticky `nonZhScope` regex `lastIndex` before testing
- add regression coverage for global regex filtering

## Verification
- `pnpm --filter pinyin-pro test -- test/nonZh.test.js`
- `pnpm --filter pinyin-pro lint`