### PR TITLE
perf(pinyin): avoid split allocation in single-word lookup

### DIFF
--- a/packages/pinyin-pro/lib/core/pinyin/handle.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/handle.ts
@@ -32,7 +32,10 @@ type GetSingleWordPinyin = (char: string) => string;
 export const getSingleWordPinyin: GetSingleWordPinyin = (char) => {
   const pinyin = DICT1.get(char);
   // 若查到, 则返回第一个拼音; 若未查到, 返回原字符
-  return pinyin ? pinyin.split(" ")[0] : char;
+  if (!pinyin) return char;
+
+  const index = pinyin.indexOf(" ");
+  return index === -1 ? pinyin : pinyin.slice(0, index);
 };
 
 const getTraditionalWords = (word: string): string => {


### PR DESCRIPTION
## What changed

`getSingleWordPinyin()` now finds the first space with `indexOf()`.

It returns the dictionary value directly when no space exists.

It uses `slice()` only for values with multiple pronunciations.

## Why

The previous code used `split(" ")[0]` for each lookup.

That code created an array when the function needed only one result.

This change follows the allocation reduction approach from #314.

## Impact

The common single-pronunciation path no longer creates a split array.

The function keeps the existing return behavior.

## Validation

- `pnpm --dir packages/data build`
- `pnpm --dir packages/pinyin-pro test`: 307 passed and 6 skipped
- `pnpm --dir packages/pinyin-pro lint`
- `pnpm --dir packages/pinyin-pro build`

Closes #335
