### PR TITLE
perf(pinyin): reuse split characters across lookup pipeline

### DIFF
--- a/packages/pinyin-pro/lib/common/segmentit/index.ts
+++ b/packages/pinyin-pro/lib/common/segmentit/index.ts
@@ -156,10 +156,13 @@ export class AC {
   }
 
   // 搜索字符串返回匹配的模式串
-  match(text: string, surname: SurnameMode) {
+  match(
+    text: string,
+    surname: SurnameMode,
+    zhChars: string[] = splitString(text),
+  ) {
     let cur = this.root;
     let result: MatchPattern[] = [];
-    const zhChars = splitString(text);
     for (let i = 0; i < zhChars.length; i++) {
       let c = zhChars[i];
 
@@ -214,14 +217,15 @@ export class AC {
     text: string,
     surname: SurnameMode,
     algorithm: TokenizationAlgorithm = TokenizationAlgorithm.MaxProbability,
+    zhChars: string[] = splitString(text),
   ) {
-    const patterns = this.match(text, surname);
+    const patterns = this.match(text, surname, zhChars);
     if (algorithm === TokenizationAlgorithm.ReverseMaxMatch) {
       return reverseMaxMatch(patterns);
     } else if (algorithm === TokenizationAlgorithm.MinTokenization) {
-      return minTokenization(patterns, stringLength(text));
+      return minTokenization(patterns, zhChars.length);
     }
-    return maxProbability(patterns, stringLength(text));
+    return maxProbability(patterns, zhChars.length);
   }
 }
 

--- a/packages/pinyin-pro/lib/core/pinyin/handle.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/handle.ts
@@ -56,12 +56,13 @@ export const getPinyin = (
   surname: SurnameMode,
   segmentit: TokenizationAlgorithm,
   traditional?: boolean,
+  zhChars: string[] = splitString(word),
 ): { list: SingleWordResult[]; matches: MatchPattern[] } => {
   ensureAcBuilt();
   const searchWord = traditional ? getTraditionalWords(word) : word;
-  const matches = acTree.search(searchWord, surname, segmentit);
+  const searchChars = traditional ? splitString(searchWord) : zhChars;
+  const matches = acTree.search(searchWord, surname, segmentit, searchChars);
   let matchIndex = 0;
-  const zhChars = splitString(word);
   for (let i = 0; i < zhChars.length; ) {
     const match = matches[matchIndex];
     if (match && i === match.index) {

--- a/packages/pinyin-pro/lib/core/pinyin/index.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/index.ts
@@ -1,4 +1,4 @@
-import { stringLength } from "@/common/utils";
+import { splitString } from "@/common/utils";
 import { TokenizationAlgorithm } from "../../common/segmentit";
 import type { PinyinMode, SurnameMode, CommonOptions } from "../../common/type";
 import { getPinyin } from "./handle";
@@ -192,7 +192,8 @@ function pinyin(
     options.nonZh = "removed";
   }
 
-  let _list = Array(stringLength(word));
+  const zhChars = splitString(word);
+  let _list = Array(zhChars.length);
 
   let { list } = getPinyin(
     word,
@@ -200,6 +201,7 @@ function pinyin(
     options.surname as SurnameMode,
     options.segmentit as TokenizationAlgorithm,
     options.traditional,
+    zhChars,
   );
 
   // 一和不变调处理

--- a/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
+++ b/packages/pinyin-pro/lib/core/pinyin/middlewares.ts
@@ -74,7 +74,7 @@ export const middlewareMultiple = (
   word: string,
   options: CompleteOptions,
 ): SingleWordResult[] | false => {
-  if (stringLength(word) === 1 && options.multiple) {
+  if (options.multiple && stringLength(word) === 1) {
     return getMultiplePinyin(word, options.surname);
   } else {
     return false;

--- a/packages/pinyin-pro/lib/core/segment/index.ts
+++ b/packages/pinyin-pro/lib/core/segment/index.ts
@@ -1,6 +1,6 @@
 import type { BasicOptions } from "../pinyin";
 import { TokenizationAlgorithm } from "../../common/segmentit";
-import { stringLength } from "@/common/utils";
+import { splitString } from "@/common/utils";
 import { middleWareNonZh, middlewareToneSandhi, middlewareToneType, middlewareV, validateType } from "@/core/pinyin/middlewares";
 import { getPinyin } from "@/core/pinyin/handle";
 import { SurnameMode } from "../../common/type";
@@ -133,14 +133,16 @@ export function segment(word: string, options?: SegmentCompleteOptions) {
     }
   }
 
-  let _list = Array(stringLength(word));
+  const zhChars = splitString(word);
+  let _list = Array(zhChars.length);
 
   let { list, matches } = getPinyin(
     word,
     _list,
     options.surname as SurnameMode,
     options.segmentit as TokenizationAlgorithm,
-    options.traditional as boolean
+    options.traditional as boolean,
+    zhChars,
   );
 
   // 一和不变调处理

--- a/packages/pinyin-pro/types/common/segmentit/index.d.ts
+++ b/packages/pinyin-pro/types/common/segmentit/index.d.ts
@@ -42,8 +42,8 @@ export declare class AC {
     addNodeToQueues(trieNode: TrieNode): void;
     insertPattern(patterns: Pattern[], pattern: Pattern): void;
     removeDict(dictName: string | symbol): void;
-    match(text: string, surname: SurnameMode): MatchPattern[];
-    search(text: string, surname: SurnameMode, algorithm?: TokenizationAlgorithm): MatchPattern[];
+    match(text: string, surname: SurnameMode, zhChars?: string[]): MatchPattern[];
+    search(text: string, surname: SurnameMode, algorithm?: TokenizationAlgorithm, zhChars?: string[]): MatchPattern[];
 }
 export declare const acTree: AC;
 export declare function ensureAcBuilt(): void;

--- a/packages/pinyin-pro/types/core/pinyin/handle.d.ts
+++ b/packages/pinyin-pro/types/core/pinyin/handle.d.ts
@@ -9,7 +9,7 @@ export { getAllPinyin } from "./all";
  */
 type GetSingleWordPinyin = (char: string) => string;
 export declare const getSingleWordPinyin: GetSingleWordPinyin;
-export declare const getPinyin: (word: string, list: SingleWordResult[], surname: SurnameMode, segmentit: TokenizationAlgorithm, traditional?: boolean) => {
+export declare const getPinyin: (word: string, list: SingleWordResult[], surname: SurnameMode, segmentit: TokenizationAlgorithm, traditional?: boolean, zhChars?: string[]) => {
     list: SingleWordResult[];
     matches: MatchPattern[];
 };


### PR DESCRIPTION
## What changed

`pinyin()` and `segment()` now split their input once.

They pass the character array through `getPinyin()` and the AC search pipeline.

AC search uses the array length for probability processing.

Existing callers can omit the new optional array parameters.

`middlewareMultiple()` now checks `options.multiple` before calculating the word length.

Traditional mode creates a second array because it searches different text.

## Why

The previous pipeline scanned the same UTF-16 input multiple times.

These scans occurred during list allocation, AC matching, and probability processing.

The default path can reuse one character array for all these operations.

## Benchmark

Median of nine alternating before/after rounds in the same Node.js process.

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| Short default input, 100,000 calls | 132.932 ms | 100.004 ms | -24.77% |
| Long default input, 200 calls | 67.219 ms | 61.964 ms | -7.82% |

## Validation

- `pnpm --dir packages/data build`
- `pnpm --dir packages/pinyin-pro test`: 307 passed and 6 skipped
- `pnpm --dir packages/pinyin-pro lint`
- `pnpm --dir packages/pinyin-pro build`
- Coverage remains 100%.

Closes #337
