### PR TITLE
fix(custom): prevent pattern accumulation on repeated updates

### DIFF
--- a/packages/pinyin-pro/lib/core/custom/index.ts
+++ b/packages/pinyin-pro/lib/core/custom/index.ts
@@ -47,6 +47,7 @@ export function customPinyin(
     priority: Priority.Custom,
     dict: CustomDictName,
   }));
+  acTree.removeDict(CustomDictName);
   acTree.build(customPatterns);
   // add words for multiple and polyphonic
   if (options?.multiple) {

--- a/packages/pinyin-pro/test/custom.test.js
+++ b/packages/pinyin-pro/test/custom.test.js
@@ -1,4 +1,5 @@
 import { pinyin, addDict, customPinyin, clearCustomDict, polyphonic } from '../lib/index';
+import { acTree } from '../lib/common/segmentit';
 import { getCustomMultipleDict, getCustomPolyphonicDict } from '../lib/core/custom';
 import { expect, describe, it } from 'vitest';
 
@@ -11,6 +12,14 @@ function clearAllCustomDicts() {
   clearCustomDict('multiple');
   clearCustomDict('polyphonic');
   clearCustomDict(['pinyin', 'multiple', 'polyphonic']);
+}
+
+function getPatternCount() {
+  let count = 0;
+  acTree.dictMap.forEach((patterns) => {
+    count += patterns.size;
+  });
+  return count;
 }
 
 describe('customConfig', () => {
@@ -117,6 +126,25 @@ describe('customConfig', () => {
     const result = pinyin('银行');
     expect(result).to.be.equal('yin hang');
     clearAllCustomDicts();
+  });
+
+  it('[custom] repeated updates do not accumulate patterns', () => {
+    clearAllCustomDicts();
+    const initialPatternCount = getPatternCount();
+    const config = {
+      银行: 'yin hang',
+      重庆: 'chong qing',
+    };
+
+    for (let i = 0; i < 1000; i++) {
+      customPinyin(config);
+    }
+
+    expect(pinyin('银行重庆')).to.be.equal('yin hang chong qing');
+    expect(getPatternCount()).to.be.equal(initialPatternCount + 2);
+
+    clearAllCustomDicts();
+    expect(getPatternCount()).to.be.equal(initialPatternCount);
   });
 
   it('[custom] double unicode1', () => {


### PR DESCRIPTION
## What changed

`customPinyin()` now removes the previous custom patterns before rebuilding them.

The accumulated custom dictionary remains unchanged.

A regression test calls `customPinyin()` 1,000 times with two entries.

The test checks output, pattern count, and cleanup.

## Root cause

Each update created new pattern objects for every accumulated dictionary entry.

The AC dictionary map stored each new object in its pattern set.

The previous custom patterns remained registered.

Repeated calls therefore increased the set and node pattern arrays.

## Impact

Repeated updates now keep one pattern per custom dictionary entry.

`clearCustomDict()` no longer processes the full update history.

This change does not introduce the overlay AC architecture from #332.

## Benchmark

The local comparison used five rounds and reported median cleanup time.

| Historical updates | Before | After |
| ---: | ---: | ---: |
| 100 | 0.132 ms | 0.005 ms |
| 1,000 | 11.834 ms | 0.004 ms |

The output remained `yin hang chong qing` in each case.

## Validation

- `pnpm --dir packages/data build`
- `pnpm --dir packages/pinyin-pro test`: 308 passed and 6 skipped
- `pnpm --dir packages/pinyin-pro lint`
- `pnpm --dir packages/pinyin-pro build`
- Coverage remains 100%.

Closes #339
