### PR TITLE
perf(segmentit): reuse child lookup in AC match

### DIFF
--- a/packages/pinyin-pro/lib/common/segmentit/index.ts
+++ b/packages/pinyin-pro/lib/common/segmentit/index.ts
@@ -163,15 +163,19 @@ export class AC {
     let result: MatchPattern[] = [];
     for (let i = 0; i < zhChars.length; i++) {
       let c = zhChars[i];
+      let next = cur.children.size ? cur.children.get(c) : undefined;
 
-      while (cur !== null && !cur.children.has(c)) {
-        cur = cur.fail as TrieNode;
+      while (!next && cur !== this.root) {
+        if (!cur.fail) {
+          cur = this.root;
+          break;
+        }
+        cur = cur.fail;
+        next = cur.children.size ? cur.children.get(c) : undefined;
       }
 
-      if (cur === null) {
-        cur = this.root;
-      } else {
-        cur = cur.children.get(c) as TrieNode;
+      if (next) {
+        cur = next;
         const pattern = cur.patterns.find((item) => {
           if (surname === "off") {
             return item.priority !== Priority.Surname;

--- a/packages/pinyin-pro/test/segmentit.test.js
+++ b/packages/pinyin-pro/test/segmentit.test.js
@@ -1,12 +1,45 @@
 import { pinyin, addDict, customPinyin } from '../lib/index';
 import { expect, describe, it, vi } from 'vitest';
-import { scheduleAcBuild } from '../lib/common/segmentit';
+import { AC, scheduleAcBuild } from '../lib/common/segmentit';
 
 const completeDict = require("@pinyin-pro/data/complete.json");
 
 addDict(completeDict);
 
 describe('segmentit', () => {
+  it('[segmentit]match after root miss and fail fallback', () => {
+    const ac = new AC();
+    const createPattern = (zh, pinyin) => ({
+      zh,
+      pinyin,
+      probability: 1,
+      length: zh.length,
+      priority: 1,
+      dict: 'test',
+    });
+    ac.build([
+      createPattern('中华', 'zhōng huá'),
+      createPattern('华人', 'huá rén'),
+    ]);
+
+    const result = ac.match('甲中华人', 'off').map(({ zh, index }) => ({
+      zh,
+      index,
+    }));
+
+    expect(result).toEqual([
+      { zh: '中华', index: 1 },
+      { zh: '华人', index: 2 },
+    ]);
+
+    const trieOnly = new AC();
+    trieOnly.buildTrie([createPattern('中华', 'zhōng huá')]);
+    expect(
+      trieOnly.match('中甲中华', 'off').map(({ zh, index }) => ({ zh, index })),
+    ).toEqual([{ zh: '中华', index: 2 }]);
+    expect(trieOnly.match('中中华', 'off')).toEqual([]);
+  });
+
   it('[segmentit]schedule idle build when requestIdleCallback is available', () => {
     const requestIdleCallback = vi.fn((callback) => callback());
     vi.stubGlobal('requestIdleCallback', requestIdleCallback);


### PR DESCRIPTION
## Summary

- Reuse each `children.get(c)` result in `AC.match()`.
- Remove the successful `Map.has()` and `Map.get()` pair.
- Skip child lookup when a trie node has no children.
- Safely fall back to root when a fail pointer is missing.
- Add tests for root miss and fail fallback paths.

## Benchmark

The benchmark calls `AC.match()` on one built trie. Each measurement uses nine samples after warm-up. The table reports medians from repeated runs.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Short text | 0.397 us | 0.332 us | -16% |
| Long text | 204.236 us | 167.516 us | -18% |
| No phrase match | 42.403 us | 37.994 us | -10% |
| Many phrase matches | 140.319 us | 130.079 us | -7% |

## Size

The total ESM API size changes from 558.56 KB to 558.62 KB. The gzip size changes from 157.31 KB to 157.34 KB.

## Checks

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm size`

All 309 active tests pass. The test coverage remains at 100%.

Closes #345