### PR TITLE
perf(segmentit): reconstruct max probability path with backpointers

### DIFF
--- a/packages/pinyin-pro/lib/common/segmentit/max-probability.ts
+++ b/packages/pinyin-pro/lib/common/segmentit/max-probability.ts
@@ -4,12 +4,15 @@ import { Probability, Priority } from "../constant";
 type ProbabilityItem = {
   probability: number;
   decimal: number; // 为防止小数溢出，decimal 标识 Math.pow(1e-300, decimal)
-  patterns: MatchPattern[];
-  concatPattern?: MatchPattern;
+  pattern?: MatchPattern;
+  nextIndex: number;
 };
 
 // 根据 probability 和 decimal 获取两个概率中最大的
-function getMaxProbability(a: ProbabilityItem, b: ProbabilityItem) {
+function getMaxProbability(
+  a: ProbabilityItem | undefined,
+  b: ProbabilityItem,
+) {
   if (!a) {
     return b;
   }
@@ -43,22 +46,25 @@ function getPatternDecimal(pattern: MatchPattern) {
 // 最大概率算法
 export function maxProbability(patterns: MatchPattern[], length: number) {
   const dp: ProbabilityItem[] = [];
+  const terminalDP: ProbabilityItem = {
+    probability: 1,
+    decimal: 0,
+    nextIndex: length,
+  };
   let patternIndex = patterns.length - 1;
   let pattern = patterns[patternIndex];
   // 按照长度去除重叠词
   for (let i = length - 1; i >= 0; i--) {
     // suffix
-    const suffixDP =
-      i + 1 >= length
-        ? { probability: 1, decimal: 0, patterns: [] as MatchPattern[] }
-        : dp[i + 1];
+    const suffixDP = i + 1 >= length ? terminalDP : dp[i + 1];
+    const nextIndex = suffixDP.pattern ? i + 1 : suffixDP.nextIndex;
     while (pattern && pattern.index + pattern.length - 1 === i) {
       const startIndex = pattern.index;
       const curDP = {
         probability: pattern.probability * suffixDP.probability,
         decimal: suffixDP.decimal + getPatternDecimal(pattern),
-        patterns: suffixDP.patterns,
-        concatPattern: pattern,
+        pattern,
+        nextIndex,
       };
       checkDecimal(curDP);
       dp[startIndex] = getMaxProbability(dp[startIndex], curDP);
@@ -68,15 +74,20 @@ export function maxProbability(patterns: MatchPattern[], length: number) {
     const iDP = {
       probability: Probability.Unknown * suffixDP.probability,
       decimal: 0,
-      patterns: suffixDP.patterns,
+      nextIndex,
     };
     checkDecimal(iDP);
     dp[i] = getMaxProbability(dp[i], iDP);
-    if (dp[i].concatPattern) {
-      dp[i].patterns = dp[i].patterns.concat(dp[i].concatPattern as MatchPattern);
-      dp[i].concatPattern = undefined;
-      delete dp[i + 1];
-    }
   }
-  return dp[0].patterns.reverse();
+
+  const result: MatchPattern[] = [];
+  let index = 0;
+  while (index < length) {
+    const item = dp[index];
+    if (item.pattern) {
+      result.push(item.pattern);
+    }
+    index = item.nextIndex;
+  }
+  return result;
 }

--- a/packages/pinyin-pro/test/max-probability.test.js
+++ b/packages/pinyin-pro/test/max-probability.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { maxProbability } from '../lib/common/segmentit/max-probability';
+import { Priority } from '../lib/common/constant';
+
+const createPattern = (
+  zh,
+  index,
+  length,
+  probability = 1,
+  priority = Priority.Normal,
+) => ({
+  zh,
+  pinyin: zh,
+  probability,
+  length,
+  priority,
+  dict: 'test',
+  index,
+});
+
+const getPatternNames = (patterns, length) =>
+  maxProbability(patterns, length).map((pattern) => pattern.zh);
+
+describe('maxProbability', () => {
+  it('reconstructs normal and overlapping phrase paths', () => {
+    expect(
+      getPatternNames(
+        [
+          createPattern('甲乙', 0, 2, 0.9),
+          createPattern('丙丁', 2, 2, 0.8),
+        ],
+        4,
+      ),
+    ).toEqual(['甲乙', '丙丁']);
+
+    expect(
+      getPatternNames(
+        [
+          createPattern('甲', 0, 1, 0.5),
+          createPattern('甲乙', 0, 2, 0.25),
+          createPattern('乙', 1, 1, 0.5),
+        ],
+        2,
+      ),
+    ).toEqual(['甲', '乙']);
+  });
+
+  it('preserves custom and surname priority', () => {
+    expect(
+      getPatternNames(
+        [
+          createPattern('甲', 0, 1, 1e-200, Priority.Custom),
+          createPattern('甲乙', 0, 2, 1),
+        ],
+        2,
+      ),
+    ).toEqual(['甲']);
+
+    expect(
+      getPatternNames(
+        [
+          createPattern('甲', 0, 1),
+          createPattern('甲乙', 0, 2, 1e-200, Priority.Surname),
+          createPattern('乙', 1, 1),
+        ],
+        2,
+      ),
+    ).toEqual(['甲乙']);
+  });
+
+  it('handles unknown characters and decimal rollover', () => {
+    expect(getPatternNames([], 3)).toEqual([]);
+
+    expect(
+      getPatternNames(
+        [createPattern('甲', 0, 1, 1e-310)],
+        1,
+      ),
+    ).toEqual([]);
+
+    expect(
+      getPatternNames(
+        [createPattern('甲', 0, 1, 1e-310, Priority.Custom)],
+        1,
+      ),
+    ).toEqual(['甲']);
+  });
+});


### PR DESCRIPTION
## Summary

- Store one selected pattern and its backpointer in each DP state.
- Reconstruct the final pattern sequence after the DP finishes.
- Remove path arrays, `concatPattern`, `Array.concat()`, `delete`, and `reverse()`.
- Keep `minTokenization()` unchanged.

## Performance

Each benchmark uses warm-up and nine samples. The results report the median.

### `maxProbability()` isolated

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Long text | 643.883 us | 259.589 us | -60% |
| Many overlapping patterns | 3974.810 us | 1094.472 us | -72% |

### End-to-end `pinyin()`

The input contains 10,000 characters. Both versions produce identical output.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| `pinyin(longText)` | 3.198 ms | 2.731 ms | -13.98% |

The end-to-end harness uses five rounds. Each round contains nine samples and alternates the measurement order.

These results use the current base commit. The end-to-end result will run again after the final rebase.

## Equivalence

The tests cover normal phrases, overlapping phrases, custom priority, surname priority, unknown characters, and decimal rollover.

A deterministic differential test compared 5,000 generated pattern sets with the previous algorithm. All outputs matched.

## Checks

- `pnpm test`
- `pnpm lint`
- `pnpm build`

All 311 active tests pass. The test coverage remains at 100%.

`pnpm size` has not run for this draft. PRs #344 and #346 currently modify the generated size documents. This branch will rebase and update those documents after the earlier work lands.

Closes #347