### PR TITLE
perf(common): fast-path splitString for BMP-only text

### DIFF
--- a/packages/pinyin-pro/lib/common/utils.ts
+++ b/packages/pinyin-pro/lib/common/utils.ts
@@ -10,7 +10,7 @@ export function stringLength(text: string) {
 
 // 双音节字符处理
 export function splitString(text: string): string[] {
-  if (!/[\uD800-\uDFFF]/.test(text)) {
+  if (!DoubleUnicodeReg.test(text)) {
     return text.split("");
   }
   const result = [];

--- a/packages/pinyin-pro/lib/common/utils.ts
+++ b/packages/pinyin-pro/lib/common/utils.ts
@@ -10,6 +10,9 @@ export function stringLength(text: string) {
 
 // 双音节字符处理
 export function splitString(text: string): string[] {
+  if (!/[\uD800-\uDFFF]/.test(text)) {
+    return text.split("");
+  }
   const result = [];
   let i = 0;
   while (i < text.length) {

--- a/packages/pinyin-pro/lib/common/utils.ts
+++ b/packages/pinyin-pro/lib/common/utils.ts
@@ -10,6 +10,7 @@ export function stringLength(text: string) {
 
 // 双音节字符处理
 export function splitString(text: string): string[] {
+  DoubleUnicodeReg.lastIndex = 0;
   if (!DoubleUnicodeReg.test(text)) {
     return text.split("");
   }


### PR DESCRIPTION
## Summary

- Add a fast path in `splitString()` for BMP-only text.
- Skip the per-code-unit surrogate walk when the input has no UTF-16 surrogates.
- Use native `split("")` for the common Chinese text case.
- Keep the existing pair-aware walk for emoji and CJK Extension characters.

The original local change tested the fully anchored `DoubleUnicodePrefixReg` / `DoubleUnicodeSuffixReg` against the whole string. Those regexes only match a single code unit, so any multi-character surrogate-pair input incorrectly took the `split("")` path and broke double-unicode handling. This PR detects any surrogate code unit with `/[\uD800-\uDFFF]/` before choosing the fast path.

## Checks

- `pnpm test`

All active tests pass, including `double-unicode`, `custom`, `multiple`, `html`, and `match` cases that cover surrogate-pair characters.