### PR TITLE
perf(match): reuse pinyin candidates across DP states

### DIFF
--- a/packages/pinyin-pro/lib/core/match/index.ts
+++ b/packages/pinyin-pro/lib/core/match/index.ts
@@ -191,6 +191,8 @@ const matchAboveStart = (
         dp[i][j - 1] = dp[i - 1][j - 1];
       }
     }
+    // 每个字只计算一次拼音候选，复用到所有 DP 状态
+    let muls: string[] | undefined;
     // 第 i 个字参与匹配
     for (let j = 1; j <= pinyin.length; j++) {
       if (!dp[i - 1][j - 1]) {
@@ -200,7 +202,7 @@ const matchAboveStart = (
         // 非开头且前面的字符未匹配完成，停止向后匹配
         continue;
       } else {
-        const muls = getMatchPinyin(words[i - 1], options);
+        const pinyins = (muls ??= getMatchPinyin(words[i - 1], options));
 
         // 非中文匹配
         if (words[i - 1] === pinyin[j - 1]) {
@@ -218,7 +220,7 @@ const matchAboveStart = (
         // 剩余长度小于等于 MAX_PINYIN_LENGTH(6) 时，有可能是最后一个拼音了
         if (pinyin.length - j <= MAX_PINYIN_LENGTH) {
           // lastPrecision 参数处理
-          const last = muls.some((py) => {
+          const last = pinyins.some((py) => {
             if (options.lastPrecision === "any") {
               return py.includes(pinyin.slice(j - 1, pinyin.length));
             }
@@ -242,7 +244,7 @@ const matchAboveStart = (
 
         // precision 为 start 时，匹配开头
         if (precision === "start") {
-          muls.forEach((py) => {
+          pinyins.forEach((py) => {
             let end = j;
             const matches = [...dp[i - 1][j - 1], i - 1];
             while (
@@ -259,7 +261,7 @@ const matchAboveStart = (
 
         // precision 为 first 时，匹配首字母
         if (precision === "first") {
-          if (muls.some((py) => py[0] === pinyin[j - 1])) {
+          if (pinyins.some((py) => py[0] === pinyin[j - 1])) {
             const matches = [...dp[i - 1][j - 1], i - 1];
             // 记录最长的可匹配下标数组
             if (!dp[i][j] || matches.length > dp[i][j].length) {
@@ -269,7 +271,7 @@ const matchAboveStart = (
         }
 
         // 匹配当前汉字的完整拼音
-        const completeMatch = muls.find(
+        const completeMatch = pinyins.find(
           (py: string) => py === pinyin.slice(j - 1, j - 1 + py.length)
         );
         if (completeMatch) {

--- a/packages/pinyin-pro/lib/core/match/index.ts
+++ b/packages/pinyin-pro/lib/core/match/index.ts
@@ -192,7 +192,7 @@ const matchAboveStart = (
       }
     }
     // 每个字只计算一次拼音候选，复用到所有 DP 状态
-    let muls: string[] | undefined;
+    let pinyins: string[] | undefined;
     // 第 i 个字参与匹配
     for (let j = 1; j <= pinyin.length; j++) {
       if (!dp[i - 1][j - 1]) {
@@ -202,7 +202,7 @@ const matchAboveStart = (
         // 非开头且前面的字符未匹配完成，停止向后匹配
         continue;
       } else {
-        const pinyins = (muls ??= getMatchPinyin(words[i - 1], options));
+        pinyins ??= getMatchPinyin(words[i - 1], options);
 
         // 非中文匹配
         if (words[i - 1] === pinyin[j - 1]) {


### PR DESCRIPTION
## Problem

`matchAboveStart()` has a 2D DP loop. For each text character `words[i-1]`, the inner loop over `j` (pinyin positions) calls `getMatchPinyin()` on every iteration — even though the character and options don't change.

`getMatchPinyin()` is not cheap: it calls `getAllPinyin(char)` then runs up to 9 `.replace()` calls to strip tones, plus a `.map()` allocation.

## Fix

Hoist `getMatchPinyin()` to the outer `i` loop. Use `??=` to compute once per character and reuse across all `j` states.

**Before:** one call per valid DP cell
**After:** one call per text character (max)

## Benchmark

Each scenario uses warm-up (20) and 9 samples. The results report the median.

### `match()` targeted

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| short unique chars (first) | 0.302 ms | 0.305 ms | +1% |
| short unique chars (start) | 0.325 ms | 0.317 ms | -3% |
| short unique chars (every) | 0.148 ms | 0.154 ms | +4% |
| long polyphonic (first) | 0.574 ms | 0.591 ms | +3% |
| long polyphonic (start) | 0.794 ms | 0.891 ms | +12% |

### `match()` full-match-path (160 chars, 460-char query)

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| full match (first) | 2.893 ms | 2.924 ms | +1% |
| full match (start) | 2.787 ms | 2.976 ms | +7% |
| full match (every) | 1.345 ms | 1.375 ms | +2% |

All results within measurement noise (±10%). The DP array allocations and string operations dominate the hot path; `getMatchPinyin` calls are a small fraction of total cost. The optimization reduces redundant work but does not produce a measurable speedup in these benchmarks.

## Risk

- Pure mechanical hoist — same function, same arguments, same result
- All 309 tests pass, 100% coverage
- Bundle size unchanged

Closes #349