### PR TITLE
feat(data): fail validation on invalid entries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Validate dictionary data
+        run: pnpm --filter @pinyin-pro/data test:validate && pnpm data:validate
+
       - name: Run tests with coverage
         run: pnpm test
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -4,6 +4,7 @@
   "description": "The data directory for pinyin-pro",
   "scripts": {
     "build": "tsc && vite build",
+    "test:validate": "node --test scripts/validate.test.js",
     "validate": "node scripts/validate.js",
     "generate:modern": "node scripts/handle-modern-dict.js"
   },

--- a/packages/data/scripts/validate.js
+++ b/packages/data/scripts/validate.js
@@ -13,7 +13,12 @@ function normalizePinyin(value) {
 function validateDictionary(dictionary) {
   const invalidEntries = [];
 
-  for (const [key, entry] of Object.entries(dictionary)) {
+  for (const key in dictionary) {
+    if (!Object.hasOwn(dictionary, key)) {
+      continue;
+    }
+
+    const entry = dictionary[key];
     const value = Array.isArray(entry) ? entry[0] : undefined;
     const reasons = [];
 
@@ -26,8 +31,8 @@ function validateDictionary(dictionary) {
       const syllableCount = pinyin.split(' ').length;
       const characterCount = Array.from(key).length;
 
-      if (!/^[a-z\sü]+$/.test(pinyin)) {
-        reasons.push('pinyin contains invalid characters');
+      if (!/^[a-zü]+(?: [a-zü]+)*$/.test(pinyin)) {
+        reasons.push('pinyin has an invalid format');
       }
       if (syllableCount !== characterCount) {
         reasons.push(
@@ -46,7 +51,13 @@ function validateDictionary(dictionary) {
 
 function runValidation(dictionary, output = console) {
   const invalidEntries = validateDictionary(dictionary);
-  const entryCount = Object.keys(dictionary).length;
+  let entryCount = 0;
+
+  for (const key in dictionary) {
+    if (Object.hasOwn(dictionary, key)) {
+      entryCount += 1;
+    }
+  }
 
   if (invalidEntries.length > 0) {
     for (const { key, pinyin, reasons } of invalidEntries) {

--- a/packages/data/scripts/validate.js
+++ b/packages/data/scripts/validate.js
@@ -1,5 +1,3 @@
-const jieba = require('../data/complete.json');
-
 function normalizePinyin(value) {
   return value
     .replace(/(ā|á|ǎ|à)/g, 'a')
@@ -15,8 +13,7 @@ function normalizePinyin(value) {
 function validateDictionary(dictionary) {
   const invalidEntries = [];
 
-  for (const key in dictionary) {
-    const entry = dictionary[key];
+  for (const [key, entry] of Object.entries(dictionary)) {
     const value = Array.isArray(entry) ? entry[0] : undefined;
     const reasons = [];
 
@@ -66,6 +63,7 @@ function runValidation(dictionary, output = console) {
 }
 
 if (require.main === module) {
+  const jieba = require('../data/complete.json');
   process.exitCode = runValidation(jieba);
 }
 

--- a/packages/data/scripts/validate.js
+++ b/packages/data/scripts/validate.js
@@ -1,7 +1,7 @@
-const jieba = require('../data/complete.json')
+const jieba = require('../data/complete.json');
 
-for(let key in jieba) {
-  const pinyin = jieba[key][0]
+function normalizePinyin(value) {
+  return value
     .replace(/(ā|á|ǎ|à)/g, 'a')
     .replace(/(ō|ó|ǒ|ò)/g, 'o')
     .replace(/(ē|é|ě|è)/g, 'e')
@@ -10,7 +10,63 @@ for(let key in jieba) {
     .replace(/(ǖ|ǘ|ǚ|ǜ)/g, 'ü')
     .replace(/(ń|ň|ǹ)/g, 'n')
     .replace(/ḿ|m̀/g, 'm');
-  if (!/^[a-z\sü]+$/.test(pinyin) || pinyin.split(' ').length !== key.length) {
-    console.log(key, pinyin)
+}
+
+function validateDictionary(dictionary) {
+  const invalidEntries = [];
+
+  for (const key in dictionary) {
+    const entry = dictionary[key];
+    const value = Array.isArray(entry) ? entry[0] : undefined;
+    const reasons = [];
+
+    if (!Array.isArray(entry)) {
+      reasons.push('entry is not an array');
+    } else if (typeof value !== 'string') {
+      reasons.push('pinyin is not a string');
+    } else {
+      const pinyin = normalizePinyin(value);
+      const syllableCount = pinyin.split(' ').length;
+      const characterCount = Array.from(key).length;
+
+      if (!/^[a-z\sü]+$/.test(pinyin)) {
+        reasons.push('pinyin contains invalid characters');
+      }
+      if (syllableCount !== characterCount) {
+        reasons.push(
+          `expected ${characterCount} syllables but found ${syllableCount}`,
+        );
+      }
+    }
+
+    if (reasons.length > 0) {
+      invalidEntries.push({ key, pinyin: value, reasons });
+    }
+  }
+
+  return invalidEntries;
+}
+
+function runValidation(dictionary, output = console) {
+  const invalidEntries = validateDictionary(dictionary);
+  const entryCount = Object.keys(dictionary).length;
+
+  if (invalidEntries.length > 0) {
+    for (const { key, pinyin, reasons } of invalidEntries) {
+      output.error(`${key}: ${String(pinyin)} (${reasons.join('; ')})`);
+    }
+    output.error(
+      `Validation failed: ${invalidEntries.length} of ${entryCount} entries are invalid.`,
+    );
+    return 1;
+  } else {
+    output.log(`Validation passed: ${entryCount} entries are valid.`);
+    return 0;
   }
 }
+
+if (require.main === module) {
+  process.exitCode = runValidation(jieba);
+}
+
+module.exports = { normalizePinyin, runValidation, validateDictionary };

--- a/packages/data/scripts/validate.test.js
+++ b/packages/data/scripts/validate.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { runValidation, validateDictionary } = require('./validate');
+
+test('accepts one non-BMP character with one pinyin syllable', () => {
+  const invalidEntries = validateDictionary({ '𠀀': ['hē'] });
+
+  assert.deepEqual(invalidEntries, []);
+});
+
+test('reports invalid characters and syllable counts', () => {
+  const invalidEntries = validateDictionary({
+    中国: ['zhōng'],
+    文: ['wén1'],
+  });
+
+  assert.deepEqual(invalidEntries, [
+    {
+      key: '中国',
+      pinyin: 'zhōng',
+      reasons: ['expected 2 syllables but found 1'],
+    },
+    {
+      key: '文',
+      pinyin: 'wén1',
+      reasons: ['pinyin contains invalid characters'],
+    },
+  ]);
+});
+
+test('returns a failure exit code and prints a summary for invalid data', () => {
+  const errors = [];
+  const exitCode = runValidation(
+    { 中国: ['zhōng'] },
+    { error: (message) => errors.push(message), log: () => {} },
+  );
+
+  assert.equal(exitCode, 1);
+  assert.deepEqual(errors, [
+    '中国: zhōng (expected 2 syllables but found 1)',
+    'Validation failed: 1 of 1 entries are invalid.',
+  ]);
+});

--- a/packages/data/scripts/validate.test.js
+++ b/packages/data/scripts/validate.test.js
@@ -23,9 +23,28 @@ test('reports invalid characters and syllable counts', () => {
     {
       key: '文',
       pinyin: 'wén1',
-      reasons: ['pinyin contains invalid characters'],
+      reasons: ['pinyin has an invalid format'],
     },
   ]);
+});
+
+test('requires one ASCII space between pinyin syllables', () => {
+  for (const [pinyin, syllableCount] of [
+    ['zhōng  guó', 3],
+    ['zhōng\tguó', 1],
+    ['zhōng\nguó', 1],
+  ]) {
+    assert.deepEqual(validateDictionary({ 中国: [pinyin] }), [
+      {
+        key: '中国',
+        pinyin,
+        reasons: [
+          'pinyin has an invalid format',
+          `expected 2 syllables but found ${syllableCount}`,
+        ],
+      },
+    ]);
+  }
 });
 
 test('reports malformed dictionary entries', () => {

--- a/packages/data/scripts/validate.test.js
+++ b/packages/data/scripts/validate.test.js
@@ -28,6 +28,26 @@ test('reports invalid characters and syllable counts', () => {
   ]);
 });
 
+test('reports malformed dictionary entries', () => {
+  const invalidEntries = validateDictionary({
+    一: 'yī',
+    二: [],
+  });
+
+  assert.deepEqual(invalidEntries, [
+    {
+      key: '一',
+      pinyin: undefined,
+      reasons: ['entry is not an array'],
+    },
+    {
+      key: '二',
+      pinyin: undefined,
+      reasons: ['pinyin is not a string'],
+    },
+  ]);
+});
+
 test('returns a failure exit code and prints a summary for invalid data', () => {
   const errors = [];
   const exitCode = runValidation(

--- a/packages/data/scripts/validate.test.js
+++ b/packages/data/scripts/validate.test.js
@@ -48,6 +48,15 @@ test('reports malformed dictionary entries', () => {
   ]);
 });
 
+test('ignores inherited enumerable properties', () => {
+  const dictionary = Object.create({
+    inherited: ['yī'],
+  });
+  dictionary.一 = ['yī'];
+
+  assert.deepEqual(validateDictionary(dictionary), []);
+});
+
 test('returns a failure exit code and prints a summary for invalid data', () => {
   const errors = [];
   const exitCode = runValidation(


### PR DESCRIPTION
Closes #354

## Summary

- Collect all invalid dictionary entries.
- Return exit status 1 when validation fails.
- Print a final validation summary.
- Count Unicode code points instead of UTF-16 code units.
- Add regression tests and run validation in CI.

## Verification

- `pnpm --filter @pinyin-pro/data test:validate`
- `pnpm data:validate`
- `node --check packages/data/scripts/validate.js`
- `node --check packages/data/scripts/validate.test.js`
- `git diff --check`