### PR TITLE
perf(match): reconstruct match paths with backpointers

### DIFF
--- a/packages/pinyin-pro/lib/core/match/index.ts
+++ b/packages/pinyin-pro/lib/core/match/index.ts
@@ -168,6 +168,27 @@ const matchAny = (
   return result.length ? result : null;
 };
 
+type MatchPath = {
+  readonly previous: MatchPath | null;
+  readonly index: number;
+  readonly length: number;
+};
+
+const appendMatchPath = (previous: MatchPath, index: number): MatchPath => ({
+  previous,
+  index,
+  length: previous.length + 1,
+});
+
+function restoreMatchPath(path: MatchPath): number[] {
+  const result = Array<number>(path.length);
+  while (path.previous) {
+    result[path.length - 1] = path.index;
+    path = path.previous;
+  }
+  return result;
+}
+
 const matchAboveStart = (
   text: string,
   pinyin: string,
@@ -175,16 +196,17 @@ const matchAboveStart = (
 ) => {
   const words = splitString(text);
 
-  // dp 只保留上一行 pre 和当前行 current
-  let pre = Array(pinyin.length + 1);
+  // Shared paths must stay immutable because multiple states can reference them.
+  const rootPath: MatchPath = { previous: null, index: -1, length: 0 };
+  let pre = Array<MatchPath | undefined>(pinyin.length + 1);
   for (let i = 0; i < pre.length; i++) {
-    pre[i] = [];
+    pre[i] = rootPath;
   }
 
   // 动态规划匹配
   for (let i = 1; i <= words.length; i++) {
-    const current = Array(pinyin.length + 1);
-    current[0] = [];
+    const current = Array<MatchPath | undefined>(pinyin.length + 1);
+    current[0] = rootPath;
     // options.continuous 为 false 或 options.space 为 ignore 且当前为空格时，第 i 个字可以不参与匹配
     if (
       !options.continuous ||
@@ -199,10 +221,11 @@ const matchAboveStart = (
     let muls: string[] | undefined;
     // 第 i 个字参与匹配
     for (let j = 1; j <= pinyin.length; j++) {
-      if (!pre[j - 1]) {
+      const previous = pre[j - 1];
+      if (!previous) {
         // 第 i - 1 已经匹配失败，停止向后匹配
         continue;
-      } else if (j !== 1 && !pre[j - 1].length) {
+      } else if (j !== 1 && !previous.length) {
         // 非开头且前面的字符未匹配完成，停止向后匹配
         continue;
       } else {
@@ -210,14 +233,14 @@ const matchAboveStart = (
 
         // 非中文匹配
         if (words[i - 1] === pinyin[j - 1]) {
-          const matches = [...pre[j - 1], i - 1];
+          const matches = appendMatchPath(previous, i - 1);
           // 记录最长的可匹配下标数组
-          if (!current[j] || matches.length > current[j].length) {
+          if (matches.length > (current[j]?.length ?? -1)) {
             current[j] = matches;
           }
           // pinyin 参数完全匹配完成，记录结果
           if (j === pinyin.length) {
-            return current[j];
+            return restoreMatchPath(current[j] ?? matches);
           }
         }
 
@@ -240,7 +263,7 @@ const matchAboveStart = (
             return false;
           });
           if (last) {
-            return [...pre[j - 1], i - 1];
+            return restoreMatchPath(appendMatchPath(previous, i - 1));
           }
         }
 
@@ -250,12 +273,12 @@ const matchAboveStart = (
         if (precision === "start") {
           muls.forEach((py) => {
             let end = j;
-            const matches = [...pre[j - 1], i - 1];
+            const matches = appendMatchPath(previous, i - 1);
             while (
               end <= pinyin.length &&
               py.startsWith(pinyin.slice(j - 1, end))
             ) {
-              if (!current[end] || matches.length > current[end].length) {
+              if (matches.length > (current[end]?.length ?? -1)) {
                 current[end] = matches;
               }
               end++;
@@ -266,9 +289,9 @@ const matchAboveStart = (
         // precision 为 first 时，匹配首字母
         if (precision === "first") {
           if (muls.some((py) => py[0] === pinyin[j - 1])) {
-            const matches = [...pre[j - 1], i - 1];
+            const matches = appendMatchPath(previous, i - 1);
             // 记录最长的可匹配下标数组
-            if (!current[j] || matches.length > current[j].length) {
+            if (matches.length > (current[j]?.length ?? -1)) {
               current[j] = matches;
             }
           }
@@ -279,10 +302,10 @@ const matchAboveStart = (
           (py: string) => py === pinyin.slice(j - 1, j - 1 + py.length)
         );
         if (completeMatch) {
-          const matches = [...pre[j - 1], i - 1];
+          const matches = appendMatchPath(previous, i - 1);
           const endIndex = j - 1 + completeMatch.length;
           // 记录最长的可匹配下标数组
-          if (!current[endIndex] || matches.length > current[endIndex].length) {
+          if (matches.length > (current[endIndex]?.length ?? -1)) {
             current[endIndex] = matches;
           }
         }

--- a/packages/pinyin-pro/test/match.test.js
+++ b/packages/pinyin-pro/test/match.test.js
@@ -2,6 +2,43 @@ import { match, customPinyin, clearCustomDict } from "../lib/index";
 import { expect, describe, it } from "vitest";
 
 describe("match", () => {
+  it("[match]keeps the longest path across shared prefixes", () => {
+    expect(match("哈啊哈", "haha", {
+      precision: "start",
+      lastPrecision: "every",
+    })).to.deep.equal([0, 1, 2]);
+  });
+
+  it("[match]keeps the first path when lengths are equal", () => {
+    expect(match("哈哈哈", "hh", {
+      precision: "first",
+      lastPrecision: "first",
+    })).to.deep.equal([0, 1]);
+    expect(match("哈哈哈", "haha", {
+      precision: "every",
+      lastPrecision: "every",
+    })).to.deep.equal([0, 1]);
+  });
+
+  it("[match]keeps literal matches and skipped character indices", () => {
+    expect(match("哈a哈a", "haa", {
+      precision: "start",
+      lastPrecision: "every",
+    })).to.deep.equal([0, 1]);
+    expect(match("𠮷哈 空 哈", "hh")).to.deep.equal([2, 6]);
+    expect(match("哈 哈", "hh", { continuous: true })).to.deep.equal([0, 2]);
+  });
+
+  it("[match]returns a long path and rejects a final mismatch", () => {
+    const text = "汉".repeat(128);
+    const query = "h".repeat(128);
+    expect(match(text, query, {
+      precision: "first",
+      lastPrecision: "first",
+    })).to.deep.equal(Array.from({ length: 128 }, (_, index) => index));
+    expect(match(text, query + "z", { precision: "first" })).to.deep.equal(null);
+  });
+
   it("[match]default", () => {
     const result = match("欢迎使用汉语拼音", "hy");
     expect(result).to.deep.equal([0, 1]);


### PR DESCRIPTION
## Problem and change

`matchAboveStart()` copies a complete index array for each reachable transition.
Long queries can build many long paths before the final character fails.
Rolling rows reduce retained rows, but they do not remove these path copies.

This change stores immutable predecessor nodes with an index and path length.
A successful match reconstructs its index array once.
The public API, transition order, tie handling, and early-return rules stay unchanged.

Four regression tests cover longest paths, equal-length ties, literal characters, Unicode indices, ignored spaces, and long paths.
The pull request excludes generated API Size tables.

Closes #366.

## Test background

- Baseline: upstream `main`, `14b898d6aff00c9df75be351667bcc4155da395b`.
- Candidate: `1ab9a10ee63b34b0673b5b6ac3601716fd7b06f7`.
- Runtime: Node 24.15.0, pnpm 10.8.0, Linux/WSL2.
- CPU: AMD Ryzen 7 8745HS.
- Both versions use fresh production CommonJS builds and identical installed dependencies.

The comparison targets allocation costs within `match()`.
It measures elapsed time and process memory, not CPU utilization.

## Correctness and required checks

- A local deterministic comparison checks 60,240 cases against the baseline. All complete returned arrays agree.
- The generator starts with seed `71839`.
- Cases cover all four precisions, final precisions, continuous matching, spaces, case handling, and `v` replacements.
- Inputs include polyphonic characters, Latin characters, supplementary Unicode characters, and emoji.
- Comparison phases use default dictionaries, custom readouts, and cleared custom dictionaries.
- Additional repeated-character cases exercise long paths and final mismatches.
- `pnpm test`: 326 tests pass. Six tests are skipped. All 30 test files pass.
- `pnpm build`, `pnpm size`, `pnpm lint`, and `git diff --check` pass.

The randomized comparison supplements the committed regression tests. It does not prove equivalence for every possible input.
Local tests use Node 24. Repository CI also checks Node 18.

## Timing method and results

Focused measurements use eight fresh processes per version, pinned to CPU 2.
Each process warms up each case for 150 ms, then measures for at least 250 ms.
Version order alternates between rounds.
The table reports the median of eight process averages in microseconds per call.
Negative changes indicate less elapsed time.

The base text contains 33 characters:

```text
汉语拼音是中文信息处理的基础能力之一，多音字识别和自定义词典导入。
```

The 528-character text repeats it 16 times.
Queries are `hanyu` (short), `hanyupinyinshizhongwenxinxichuli` (long), and `hanyupinyinshizhongwenxinxichulixyz` (final mismatch).
The `any` control uses `hypy`.

| Case | Baseline μs/call | Candidate μs/call | Time change |
|---|---:|---:|---:|
| first, 33 characters, short | 3.184 | 3.201 | +0.5% |
| start, 33 characters, short | 3.665 | 3.124 | −14.8% |
| start, 528 characters, long | 36.718 | 29.867 | −18.7% |
| start, 528 characters, final mismatch | 220.993 | 130.569 | −40.9% |
| every, 33 characters, short | 3.448 | 2.872 | −16.7% |
| every, 528 characters, final mismatch | 572.156 | 587.131 | +2.6% |
| pinyin, 528 characters, control | 78.744 | 83.234 | +5.7% |
| any, 528 characters, control | 16.911 | 17.531 | +3.7% |

Short-query results vary across runs. An earlier unpinned run shows slowdowns in multiple short-query cases.
The unchanged control paths also vary, so small differences need caution.
The consistent benefit appears in long `start` queries and populated long-path workloads.

## Memory pressure method and results

Each case uses five fresh processes per version, with alternating version order.
Each child imports the bundle, runs explicit garbage collection, then times its first `match()` call.
All queries use `precision: "first"` and must return `null`.

- Empty states: text is `"汉".repeat(n)`. Query is `"z".repeat(n)`.
- Populated states: text is `"汉".repeat(n)`. Query is `"h".repeat(n - 1) + "z"`.

Values are medians. Peak RSS comes from `process.resourceUsage().maxRSS` and includes the entire process.
Baseline peak RSS before each call is approximately 58.3–58.5 MiB.

| Case | Baseline ms | Candidate ms | Baseline peak RSS MiB | Candidate peak RSS MiB |
|---|---:|---:|---:|---:|
| Empty, 2048 characters | 62.084 | 64.139 | 72.359 | 73.246 |
| Populated, 512 characters | 75.768 | 18.013 | 81.383 | 72.324 |
| Populated, 1024 characters | 539.182 | 53.287 | 103.145 | 74.160 |

The populated 1024-character case uses about 90% less elapsed time and 28% less peak RSS.
The empty-state case does not improve.

## Reproduction

Build both revisions with the same Node version and dependency lockfile.
Run these commands from the candidate checkout:

```sh
git worktree add --detach /tmp/pinyin-path-baseline 14b898d6aff00c9df75be351667bcc4155da395b
(cd /tmp/pinyin-path-baseline && pnpm install --frozen-lockfile && pnpm build)
pnpm install --frozen-lockfile
pnpm build
pnpm test
pnpm lint
pnpm size
```

The existing matrix provides an independent timing check:

```sh
(cd /tmp/pinyin-path-baseline && taskset -c 2 node benchmark/match.js)
taskset -c 2 node benchmark/match.js
```

The existing memory benchmark accepts an explicit bundle path:

```sh
BENCH_SAMPLES=5 PINYIN_PRO_DIST=/tmp/pinyin-path-baseline/packages/pinyin-pro/dist/index.js   node packages/pinyin-pro/scripts/benchmark/match-memory.js
BENCH_SAMPLES=5 PINYIN_PRO_DIST="$PWD/packages/pinyin-pro/dist/index.js"   node packages/pinyin-pro/scripts/benchmark/match-memory.js
```

These existing scripts use different warmup and sampling details from the local measurements above.
The memory script also includes a populated 2048-character case.
Use the following isolated case to reproduce the reported memory protocol for a selected length.
Save it as `/tmp/match-path-memory.cjs`:

```js
const assert = require("node:assert/strict");
const { performance } = require("node:perf_hooks");
const { match } = require(process.argv[2]);
const n = Number(process.argv[3]);
global.gc();
const baselineMiB = process.resourceUsage().maxRSS / 1024;
const start = performance.now();
const result = match("汉".repeat(n), "h".repeat(n - 1) + "z", {
  precision: "first",
});
const elapsedMs = performance.now() - start;
assert.equal(result, null);
console.log({
  elapsedMs,
  baselineMiB,
  peakRssMiB: process.resourceUsage().maxRSS / 1024,
});
```

Run each version five times in alternating order. Compare the medians:

```sh
node --expose-gc /tmp/match-path-memory.cjs /tmp/pinyin-path-baseline/packages/pinyin-pro/dist/index.js 1024
node --expose-gc /tmp/match-path-memory.cjs "$PWD/packages/pinyin-pro/dist/index.js" 1024
```

## Limits and size cost

Predecessor nodes still consume memory. This change does not guarantee constant total memory.
Results cover this Node CommonJS environment. Browser and ESM results can differ.

Generated size changes:

- UMD bundle: 316.72 → 317.00 KB. Gzip: 138.03 → 138.10 KB.
- Match ESM API: 185.54 → 185.81 KB. Gzip: 80.87 → 80.95 KB.

These measurements come from local generated files.
The pull request does not include those files.

The production bundle SHA256 is `d51de25b4c90c14ae8a9e773cffd3d0d8724b64f80923d5159e289e38018b9a1`.
No logs, profiles, credentials, or unrelated local files are included.
